### PR TITLE
Fixed nested IEnumerator does not consumed

### DIFF
--- a/Assets/Tests/AsyncTest.cs
+++ b/Assets/Tests/AsyncTest.cs
@@ -376,6 +376,27 @@ namespace UniRx.AsyncTests
             throw new Exception("MyException");
         }
 
+        [UnityTest]
+        public IEnumerator NestedEnumerator() => UniTask.ToCoroutine(async () =>
+        {
+            var time = Time.realtimeSinceStartup;
+
+            await ParentCoroutineEnumerator();
+
+            var elapsed = Time.realtimeSinceStartup - time;
+            ((int)Math.Round(TimeSpan.FromSeconds(elapsed).TotalSeconds, MidpointRounding.ToEven)).Should().Be(3);
+        });
+
+        IEnumerator ParentCoroutineEnumerator()
+        {
+            yield return ChildCoroutineEnumerator();
+        }
+
+        IEnumerator ChildCoroutineEnumerator()
+        {
+            yield return new WaitForSeconds(3);
+        }
+
 #endif
 #endif
     }

--- a/Assets/UniRx.Async/EnumeratorAsyncExtensions.cs
+++ b/Assets/UniRx.Async/EnumeratorAsyncExtensions.cs
@@ -191,7 +191,8 @@ namespace UniRx.Async
                     }
                     else if (current is IEnumerator e3)
                     {
-                        while (e3.MoveNext())
+                        var e4 = ConsumeEnumerator(e3);
+                        while (e4.MoveNext())
                         {
                             yield return null;
                         }


### PR DESCRIPTION
#11 says `await IEnumerator` works well now, but I found it fails when a nested `IEnumerator` exists.
It seems this is because the nested `IEnumerator` does not consumed, so I tried to fix it.

**Example.**
```csharp
using System.Collections;
using UniRx.Async;
using UnityEngine;

public class AsyncEnumeratorTest : MonoBehaviour
{
    async UniTask Start()
    {
        await Func1();
    }

    IEnumerator Func1()
    {
        yield return Func2();
    }

    IEnumerator Func2()
    {
        Debug.Log("a");
        yield return new WaitForSeconds(1);
        Debug.Log("b");
    }
}
```
In `v1.0.0`, this will output `b` immediately(1 frame) after `a`.


