### PR TITLE
feat: Android il2cpp support

### DIFF
--- a/src/UniTask/ProjectSettings/ProjectSettings.asset
+++ b/src/UniTask/ProjectSettings/ProjectSettings.asset
@@ -556,6 +556,7 @@ PlayerSettings:
   scriptingDefineSymbols: {}
   platformArchitecture: {}
   scriptingBackend:
+    Android: 1
     Standalone: 1
   il2cppCompilerConfiguration: {}
   managedStrippingLevel: {}


### PR DESCRIPTION
## TL;DR

* This PR brings support to run Unity Build on UnityCloudBuild.
* Supported platform is iOS(IL2CPP) and Android(IL2CPP).

![image](https://user-images.githubusercontent.com/3856350/84242692-25df4c80-ab3c-11ea-972f-c6b955b36962.png)

## Changes

* Android build should be IL2CPP.

## Summary

Platform | Build Time | Unity Version | PostExportMethod | Enable Test
---- | ---- | ----- | ---- | ----
Android | 00:26:38 | Always Use Latest 2019.x | UnitTestBuilder.BuildUnitTest | PlatMode Tests
iOS | 00:58:28 | Always Use Latest 2019.x | UnitTestBuilder.BuildUnitTest | PlatMode Tests