### PR TITLE
Disable "Auto Referenced" of UniTask.Editor

### DIFF
--- a/src/UniTask/Assets/Plugins/UniTask/Editor/UniTask.Editor.asmdef
+++ b/src/UniTask/Assets/Plugins/UniTask/Editor/UniTask.Editor.asmdef
@@ -10,7 +10,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false


### PR DESCRIPTION
Reducing number of "Auto Referenced" will make faster compilation.
And almost nobody externally references UniTask.Editor. 