### PR TITLE
Continue to subscribe if an exception is raised when calling onNext

### DIFF
--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/Linq/Subscribe.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/Linq/Subscribe.cs
@@ -195,7 +195,14 @@ namespace Cysharp.Threading.Tasks.Linq
             {
                 while (await e.MoveNextAsync())
                 {
-                    onNext(e.Current);
+                    try
+                    {
+                        onNext(e.Current);
+                    }
+                    catch (Exception ex)
+                    {
+                        UniTaskScheduler.PublishUnobservedTaskException(ex);
+                    }
                 }
                 onCompleted();
             }
@@ -227,7 +234,14 @@ namespace Cysharp.Threading.Tasks.Linq
             {
                 while (await e.MoveNextAsync())
                 {
-                    onNext(e.Current).Forget();
+                    try
+                    {
+                        onNext(e.Current).Forget();
+                    }
+                    catch (Exception ex)
+                    {
+                        UniTaskScheduler.PublishUnobservedTaskException(ex);
+                    }
                 }
                 onCompleted();
             }
@@ -259,7 +273,14 @@ namespace Cysharp.Threading.Tasks.Linq
             {
                 while (await e.MoveNextAsync())
                 {
-                    onNext(e.Current, cancellationToken).Forget();
+                    try
+                    {
+                        onNext(e.Current, cancellationToken).Forget();
+                    }
+                    catch (Exception ex)
+                    {
+                        UniTaskScheduler.PublishUnobservedTaskException(ex);
+                    }
                 }
                 onCompleted();
             }
@@ -291,7 +312,14 @@ namespace Cysharp.Threading.Tasks.Linq
             {
                 while (await e.MoveNextAsync())
                 {
-                    observer.OnNext(e.Current);
+                    try
+                    {
+                        observer.OnNext(e.Current);
+                    }
+                    catch (Exception ex)
+                    {
+                        UniTaskScheduler.PublishUnobservedTaskException(ex);
+                    }
                 }
                 observer.OnCompleted();
             }


### PR DESCRIPTION
The same as UniRx, continue to subscribe if an exception is raised when calling onNext. 