### PR TITLE
Add UniTaskExtensions.Unwrap()

### DIFF
--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTaskExtensions.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTaskExtensions.cs
@@ -736,6 +736,26 @@ namespace Cysharp.Threading.Tasks
         {
             await await task;
         }
+        
+        public static async UniTask<T> Unwrap<T>(this Task<UniTask<T>> task)
+        {
+            return await await task;
+        }
+
+        public static async UniTask Unwrap<T>(this Task<UniTask> task)
+        {
+            await await task;
+        }
+        
+        public static async UniTask<T> Unwrap<T>(this UniTask<Task<T>> task)
+        {
+            return await await task;
+        }
+
+        public static async UniTask Unwrap<T>(this UniTask<Task> task)
+        {
+            await await task;
+        }
 
 #if UNITY_2018_3_OR_NEWER
 


### PR DESCRIPTION
Add a `Unwrap` method for `Task<UniTask>` and `UniTask<Task>`.

example:
```csharp
public static UniTask<T> Run<T>(this TaskFactory factory, Func<UniTask<T>> func)
{
    return factory.StartNew(func).Unwrap();
}
```