### PR TITLE
Optimize ContinuationQueue and PlayerLoopRunner iteration

### DIFF
--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/Internal/ContinuationQueue.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/Internal/ContinuationQueue.cs
@@ -171,7 +171,7 @@ namespace Cysharp.Threading.Tasks.Internal
             for (int i = 0; i < actionListCount; i++)
             {
 
-                var action = actionList[i];//Reduce array bounds check
+                var action = actionList[i];
                 actionList[i] = null;
                 try
                 {

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/Internal/ContinuationQueue.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/Internal/ContinuationQueue.cs
@@ -171,8 +171,8 @@ namespace Cysharp.Threading.Tasks.Internal
             for (int i = 0; i < actionListCount; i++)
             {
 
-                ref var action = ref actionList[i];//Reduce array bounds check
-
+                var action = actionList[i];//Reduce array bounds check
+                actionList[i] = null;
                 try
                 {
                     action();
@@ -181,7 +181,6 @@ namespace Cysharp.Threading.Tasks.Internal
                 {
                     UnityEngine.Debug.LogException(ex);
                 }
-                action = null;
             }
 
             {

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/Internal/ContinuationQueue.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/Internal/ContinuationQueue.cs
@@ -170,8 +170,8 @@ namespace Cysharp.Threading.Tasks.Internal
 
             for (int i = 0; i < actionListCount; i++)
             {
-                var action = actionList[i];
-                actionList[i] = null;
+
+                ref var action = ref actionList[i];//Reduce array bounds check
 
                 try
                 {
@@ -181,6 +181,7 @@ namespace Cysharp.Threading.Tasks.Internal
                 {
                     UnityEngine.Debug.LogException(ex);
                 }
+                action = null;
             }
 
             {

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/Internal/PlayerLoopRunner.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/Internal/PlayerLoopRunner.cs
@@ -143,6 +143,7 @@ namespace Cysharp.Threading.Tasks.Internal
             {
                 var j = tail - 1;
 
+                var loopItems = this.loopItems;
                 // eliminate array-bound check for i
                 for (int i = 0; i < loopItems.Length; i++)
                 {


### PR DESCRIPTION
- Fix failing to eliminate array bounds check in PlayerLoopRunner.RunCore
- Reduce number of array bounds check of continuation iteration in ContinuationQueue.RunCore