### PR TITLE
Create ContinuationQueueCheck.cs

### DIFF
--- a/src/UniTask.NetCoreSandbox/ContinuationQueueCheck.cs
+++ b/src/UniTask.NetCoreSandbox/ContinuationQueueCheck.cs
@@ -1,0 +1,282 @@
+﻿using BenchmarkDotNet.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Net.WebSockets;
+using System.Text;
+
+namespace NetCoreSandbox
+{
+    struct WrapedAction
+    {
+        Action action;
+
+        public WrapedAction(Action action)
+        {
+            this.action = action;
+        }
+
+        public void Invoke() => action.Invoke();
+    }
+
+    [Config(typeof(BenchmarkConfig))]
+    [CategoriesColumn]
+    public class ContinuationQueueCheck
+    {
+        const int actionListLength = 16;
+        Action[] actionList;
+        int actionListCount = actionListLength;
+        WrapedAction[] wrapedActionList;
+        int wrapedActionListCount = actionListLength;
+        [GlobalSetup]
+
+        public void Setup()
+        {
+            actionList = new Action[actionListLength];
+            for (int i = 0; i < actionList.Length; i++)
+            {
+                actionList[i] = () => { };
+            }
+            wrapedActionList = new WrapedAction[actionListLength];
+            for (int i = 0; i < wrapedActionList.Length; i++)
+            {
+                wrapedActionList[i] = new WrapedAction(() => { });
+            }
+        }
+
+        [Benchmark]
+        public void WithoutRef()
+        {
+            for (int i = 0; i < actionListCount; i++)
+            {
+                var action = actionList[i];
+                actionList[i] = default;
+
+                try
+                {
+                    action.Invoke();
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine(ex);
+                }
+            }
+        }
+        [Benchmark]
+        public void WithoutRefNoBoundsCheck()
+        {
+            var actionList = this.actionList;
+            for (int i = 0; i < actionList.Length; i++)
+            {
+                var action = actionList[i];
+                actionList[i] = default;
+
+                try
+                {
+                    action.Invoke();
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine(ex);
+                }
+            }
+        }
+        [Benchmark]
+        public void WithoutRefLocalListCount()
+        {
+            var actionList = this.actionList;
+            var count = Math.Min(actionList.Length, actionListCount);
+            for (int i = 0; i < count; i++)
+            {
+                var action = actionList[i];
+                actionList[i] = default;
+
+                try
+                {
+                    action.Invoke();
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine(ex);
+                }
+            }
+        }
+        [Benchmark]
+        public void WithRef()
+        {
+            for (int i = 0; i < actionListCount; i++)
+            {
+                ref var action = ref actionList[i];
+
+
+                try
+                {
+                    action.Invoke();
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine(ex);
+                }
+                action = default;
+            }
+        }
+        [Benchmark]
+        public void WithRefNoBoundsCheck()
+        {
+            var actionList = this.actionList;
+            for (int i = 0; i < actionList.Length; i++)
+            {
+                ref var action = ref actionList[i];
+
+
+                try
+                {
+                    action.Invoke();
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine(ex);
+                }
+                action = default;
+            }
+        }
+        [Benchmark]
+        public void WithRefLocalListCount()
+        {
+            var actionList = this.actionList;
+            var count = Math.Min(actionList.Length, actionListCount);
+            for (int i = 0; i < count; i++)
+            {
+                ref var action = ref actionList[i];
+
+
+                try
+                {
+                    action.Invoke();
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine(ex);
+                }
+                action = default;
+            }
+        }
+        [Benchmark]
+        public void WithoutRefWraped()
+        {
+            for (int i = 0; i < wrapedActionListCount; i++)
+            {
+                var wrapedAction = wrapedActionList[i];
+                wrapedActionList[i] = default;
+
+                try
+                {
+                    wrapedAction.Invoke();
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine(ex);
+                }
+            }
+        }
+        [Benchmark]
+        public void WithoutRefNoBoundsCheckWraped()
+        {
+            var wrapedActionList = this.wrapedActionList;
+            for (int i = 0; i < wrapedActionList.Length; i++)
+            {
+                var wrapedAction = wrapedActionList[i];
+                wrapedActionList[i] = default;
+
+                try
+                {
+                    wrapedAction.Invoke();
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine(ex);
+                }
+            }
+        }
+        [Benchmark]
+        public void WithoutRefLocalListCountWraped()
+        {
+            var wrapedActionList = this.wrapedActionList;
+            var count = Math.Min(wrapedActionList.Length, wrapedActionListCount);
+            for (int i = 0; i < count; i++)
+            {
+                var wrapedAction = wrapedActionList[i];
+                wrapedActionList[i] = default;
+
+                try
+                {
+                    wrapedAction.Invoke();
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine(ex);
+                }
+            }
+        }
+        [Benchmark]
+        public void WithRefWraped()
+        {
+            for (int i = 0; i < wrapedActionListCount; i++)
+            {
+                ref var wrapedAction = ref wrapedActionList[i];
+
+
+                try
+                {
+                    wrapedAction.Invoke();
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine(ex);
+                }
+                wrapedAction = default;
+            }
+        }
+        [Benchmark]
+        public void WithRefNoBoundsCheckWraped()
+        {
+            var wrapedActionList = this.wrapedActionList;
+            for (int i = 0; i < wrapedActionList.Length; i++)
+            {
+                ref var wrapedAction = ref wrapedActionList[i];
+
+
+                try
+                {
+                    wrapedAction.Invoke();
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine(ex);
+                }
+                wrapedAction = default;
+            }
+        }
+        [Benchmark]
+        public void WithRefLocalListCountWraped()
+        {
+            var wrapedActionList = this.wrapedActionList;
+            var count = Math.Min(wrapedActionList.Length, wrapedActionListCount);
+            for (int i = 0; i < count; i++)
+            {
+                ref var wrapedAction = ref wrapedActionList[i];
+
+
+                try
+                {
+                    wrapedAction.Invoke();
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine(ex);
+                }
+                wrapedAction = default;
+            }
+        }
+    }
+}


### PR DESCRIPTION
#147 
But it seems that benchmark not working finely
``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.450 (2004/?/20H1)
Intel Core i9-9900K CPU 3.60GHz (Coffee Lake), 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=5.0.100-preview.8.20417.9
  [Host]   : .NET Core 3.1.7 (CoreCLR 4.700.20.36602, CoreFX 4.700.20.37001), X64 RyuJIT
  ShortRun : .NET Core 3.1.7 (CoreCLR 4.700.20.36602, CoreFX 4.700.20.37001), X64 RyuJIT

Job=ShortRun  IterationCount=1  LaunchCount=1  
WarmupCount=1  

```
|                         Method |     Mean | Error |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------------- |---------:|------:|-------:|------:|------:|----------:|
|                     WithoutRef | 120.5 μs |    NA | 0.3662 |     - |     - |   3.13 KB |
|        WithoutRefNoBoundsCheck | 121.7 μs |    NA | 0.3662 |     - |     - |   3.13 KB |
|       WithoutRefLocalListCount | 121.9 μs |    NA | 0.3662 |     - |     - |   3.13 KB |
|                        WithRef | 120.2 μs |    NA | 0.3662 |     - |     - |   3.13 KB |
|           WithRefNoBoundsCheck | 121.1 μs |    NA | 0.3662 |     - |     - |   3.13 KB |
|          WithRefLocalListCount | 120.1 μs |    NA | 0.3662 |     - |     - |   3.13 KB |
|               WithoutRefWraped | 139.8 μs |    NA | 0.4883 |     - |     - |      5 KB |
|  WithoutRefNoBoundsCheckWraped | 138.0 μs |    NA | 0.4883 |     - |     - |      5 KB |
| WithoutRefLocalListCountWraped | 136.4 μs |    NA | 0.4883 |     - |     - |      5 KB |
|                  WithRefWraped | 139.2 μs |    NA | 0.4883 |     - |     - |      5 KB |
|     WithRefNoBoundsCheckWraped | 136.8 μs |    NA | 0.4883 |     - |     - |      5 KB |
|    WithRefLocalListCountWraped | 139.5 μs |    NA | 0.4883 |     - |     - |      5 KB |
