### PR TITLE
Optimize EnumeratorPromise.ConsumeEnumerator while consuming CustomYieldInstruction

### DIFF
--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/EnumeratorAsyncExtensions.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/EnumeratorAsyncExtensions.cs
@@ -162,11 +162,10 @@ namespace Cysharp.Threading.Tasks
                     {
                         yield return null;
                     }
-                    else if (current is CustomYieldInstruction)
+                    else if (current is CustomYieldInstruction cyi)
                     {
                         // WWW, WaitForSecondsRealtime
-                        var e2 = UnwrapWaitCustomYieldInstruction((CustomYieldInstruction)current);
-                        while (e2.MoveNext())
+                        while (cyi.keepWaiting)//https://github.com/Unity-Technologies/UnityCsReference/blob/4fc5eb0fb2c7f5fb09f990fc99f162c8d06d9570/Runtime/Export/Scripting/CustomYieldInstruction.cs
                         {
                             yield return null;
                         }
@@ -208,15 +207,6 @@ namespace Cysharp.Threading.Tasks
                         // WaitForEndOfFrame, WaitForFixedUpdate, others.
                         yield return null;
                     }
-                }
-            }
-
-            // WWW and others as CustomYieldInstruction.
-            static IEnumerator UnwrapWaitCustomYieldInstruction(CustomYieldInstruction yieldInstruction)
-            {
-                while (yieldInstruction.keepWaiting)
-                {
-                    yield return null;
                 }
             }
 

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/EnumeratorAsyncExtensions.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/EnumeratorAsyncExtensions.cs
@@ -164,8 +164,9 @@ namespace Cysharp.Threading.Tasks
                     }
                     else if (current is CustomYieldInstruction cyi)
                     {
+                        //https://github.com/Unity-Technologies/UnityCsReference/blob/master/Runtime/Export/Scripting/CustomYieldInstruction.cs
                         // WWW, WaitForSecondsRealtime
-                        while (cyi.keepWaiting)//https://github.com/Unity-Technologies/UnityCsReference/blob/4fc5eb0fb2c7f5fb09f990fc99f162c8d06d9570/Runtime/Export/Scripting/CustomYieldInstruction.cs
+                        while (cyi.keepWaiting)//Use keepWaiting instead of MoveNext to avoid virtual call
                         {
                             yield return null;
                         }

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/EnumeratorAsyncExtensions.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/EnumeratorAsyncExtensions.cs
@@ -164,9 +164,8 @@ namespace Cysharp.Threading.Tasks
                     }
                     else if (current is CustomYieldInstruction cyi)
                     {
-                        //https://github.com/Unity-Technologies/UnityCsReference/blob/master/Runtime/Export/Scripting/CustomYieldInstruction.cs
                         // WWW, WaitForSecondsRealtime
-                        while (cyi.keepWaiting)//Use keepWaiting instead of MoveNext to avoid virtual call
+                        while (cyi.keepWaiting)
                         {
                             yield return null;
                         }


### PR DESCRIPTION
[Let's look into CustomYieldInstrcution's implementation...](https://github.com/Unity-Technologies/UnityCsReference/blob/master/Runtime/Export/Scripting/CustomYieldInstruction.cs)

Yeah,it is just an simple IEnumerator.
Always return null,and calling MoveNext is completely equals to get keepWaiting.

[It is not only implemented,but also documented.](https://docs.unity3d.com/2020.1/Documentation/ScriptReference/CustomYieldInstruction.html)

It is documented that  keepWaiting property is queried each frame after MonoBehaviour.Update and before MonoBehaviour.LateUpdate.
This implementation do not always guarantee this restriction,but it is exactly same as current implementation about this issue.