### PR TITLE
Fix UniTaskExtensions.Unwrap()

### DIFF
--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTaskExtensions.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTaskExtensions.cs
@@ -741,20 +741,40 @@ namespace Cysharp.Threading.Tasks
         {
             return await await task;
         }
+        
+        public static async UniTask<T> Unwrap<T>(this Task<UniTask<T>> task, bool continueOnCapturedContext)
+        {
+            return await await task.ConfigureAwait(continueOnCapturedContext);
+        }
 
         public static async UniTask Unwrap(this Task<UniTask> task)
         {
             await await task;
+        }
+
+        public static async UniTask Unwrap(this Task<UniTask> task, bool continueOnCapturedContext)
+        {
+            await await task.ConfigureAwait(continueOnCapturedContext);
         }
         
         public static async UniTask<T> Unwrap<T>(this UniTask<Task<T>> task)
         {
             return await await task;
         }
+        
+        public static async UniTask<T> Unwrap<T>(this UniTask<Task<T>> task, bool continueOnCapturedContext)
+        {
+            return await (await task).ConfigureAwait(continueOnCapturedContext);
+        }
 
         public static async UniTask Unwrap(this UniTask<Task> task)
         {
             await await task;
+        }
+
+        public static async UniTask Unwrap(this UniTask<Task> task, bool continueOnCapturedContext)
+        {
+            await (await task).ConfigureAwait(continueOnCapturedContext);
         }
 
 #if UNITY_2018_3_OR_NEWER

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTaskExtensions.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTaskExtensions.cs
@@ -732,7 +732,7 @@ namespace Cysharp.Threading.Tasks
             return await await task;
         }
 
-        public static async UniTask Unwrap<T>(this UniTask<UniTask> task)
+        public static async UniTask Unwrap(this UniTask<UniTask> task)
         {
             await await task;
         }
@@ -742,7 +742,7 @@ namespace Cysharp.Threading.Tasks
             return await await task;
         }
 
-        public static async UniTask Unwrap<T>(this Task<UniTask> task)
+        public static async UniTask Unwrap(this Task<UniTask> task)
         {
             await await task;
         }
@@ -752,7 +752,7 @@ namespace Cysharp.Threading.Tasks
             return await await task;
         }
 
-        public static async UniTask Unwrap<T>(this UniTask<Task> task)
+        public static async UniTask Unwrap(this UniTask<Task> task)
         {
             await await task;
         }


### PR DESCRIPTION
- remove unnecessary type parameter
- add `ConfigureAwait` version overload

#142