### PR TITLE
Update UniTaskExtensions.cs

### DIFF
--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTaskExtensions.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTaskExtensions.cs
@@ -234,6 +234,16 @@ namespace Cysharp.Threading.Tasks
 
             return new UniTask<T>(new WithCancellationSource<T>(task, cancellationToken), 0);
         }
+        
+        /// <summary>
+        /// Cancels last running instance to ensure there are not 2 or more instances of this UniTask running and regenerates the token source
+        /// </summary>
+        public static UniTask WithLastInstanceCancellation(this UniTask task, ref CancellationTokenSource cancellationTokenSource)
+        {
+            cancellationTokenSource.Cancel();
+            cancellationTokenSource = new CancellationTokenSource();
+            return task.WithCancellation(cancellationTokenSource.Token);
+        }
 
         sealed class WithCancellationSource : IUniTaskSource
         {


### PR DESCRIPTION
Added an extension to run single-instance unitasks using CancellationTokenSourceReferences

This avoids running several instances of  unitasks using the same CancellationToenSource reference

for example, if I want an instance of UniTask terming a number to zero
and then I want to start another instance to lerp it to 1 without canceling the first one the number will be behaving weird because 2 lerps are overlapping

In order to do that correctly, I have to create a Cancellation source for starting the first lerp,
Then if I want to start the second lerp I have to ensure the first one is canceled or finished,
so I have to cancel the old lerp and start the new lerp with a new cancellation source

So I decided to create a simple extension just for automatizing that

so this is an example of usage
```csharp
int num = 2;
CancellationTokenSource cancellationSource = new CancellationTokenSource();
void Example()
{
    LerpTo1(ref num).WithLastInstanceCancellation(ref cancellationSource).Forget();
    LerpTo0(ref num).WithLastInstanceCancellation(ref cancellationSource).Forget();
    LerpTo(ref num, 40).WithLastInstanceCancellation(ref cancellationSource).Forget();
}
```

It will just make the last lerp since they are using the same cancellation token source they are treated as the same task and canceled when a new one using the same token is I being started

So in this way, the task running is bound to their cancellation sources making it easier to avoid multiple instances running unintentionally