### PR TITLE
Force complete awaiting JobHandles when quitted in UnityEditor

### DIFF
--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/PlayerLoopHelper.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/PlayerLoopHelper.cs
@@ -101,7 +101,7 @@ namespace Cysharp.Threading.Tasks
         static SynchronizationContext unitySynchronizationContetext;
         static ContinuationQueue[] yielders;
         static PlayerLoopRunner[] runners;
-
+        internal static bool IsEditorApplicationQuitting { get; private set; }
         static PlayerLoopSystem[] InsertRunner(PlayerLoopSystem loopSystem,
             Type loopRunnerYieldType, ContinuationQueue cq, Type lastLoopRunnerYieldType, ContinuationQueue lastCq,
             Type loopRunnerType, PlayerLoopRunner runner, Type lastLoopRunnerType, PlayerLoopRunner lastRunner)
@@ -112,6 +112,7 @@ namespace Cysharp.Threading.Tasks
             {
                 if (state == PlayModeStateChange.EnteredEditMode || state == PlayModeStateChange.ExitingEditMode)
                 {
+                    IsEditorApplicationQuitting = true;
                     // run rest action before clear.
                     if (runner != null)
                     {
@@ -134,6 +135,7 @@ namespace Cysharp.Threading.Tasks
                         lastCq.Run();
                         lastCq.Clear();
                     }
+                    IsEditorApplicationQuitting = false;
                 }
             };
 #endif

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/UnityAsyncExtensions.Jobs.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/UnityAsyncExtensions.Jobs.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading;
 using Unity.Jobs;
+using UnityEngine;
 
 namespace Cysharp.Threading.Tasks
 {
@@ -85,7 +86,7 @@ namespace Cysharp.Threading.Tasks
 
             public bool MoveNext()
             {
-                if (jobHandle.IsCompleted)
+                if (jobHandle.IsCompleted | PlayerLoopHelper.IsEditorApplicationQuitting)
                 {
                     jobHandle.Complete();
                     core.TrySetResult(AsyncUnit.Default);


### PR DESCRIPTION
Currently, awaiting non-completed JobHandle on application quit with `await JobHandle` or `await JobHandle.ToUniTask` doesn't call continuation.
And in most of case, this resulted in native collection leak in editor.(Because we use native collections with job)

`await JobHandle.WaitAsync` had this problem previously, and it is fixed with [change in UniTask2.0.35.](https://github.com/Cysharp/UniTask/releases/tag/2.0.35)
>Changed clear timing of internal UniTask playerloop-runner's queue for Unity Editor and run rest action when quitted.

This PR fixes the problem in other method of awaiting JobHandle in similar way.
