### PR TITLE
Accept calling DeferPromise.GetStatus multiple times

### DIFF
--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTask.Factory.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTask.Factory.cs
@@ -341,10 +341,12 @@ namespace Cysharp.Threading.Tasks
             public UniTaskStatus GetStatus(short token)
             {
                 var f = Interlocked.Exchange(ref factory, null);
-                if (f == null) throw new InvalidOperationException("Can't call twice.");
+                if (f != null)
+                {
+                    task = f();
+                    awaiter = task.GetAwaiter();
+                }
 
-                task = f();
-                awaiter = task.GetAwaiter();
                 return task.Status;
             }
 
@@ -383,10 +385,12 @@ namespace Cysharp.Threading.Tasks
             public UniTaskStatus GetStatus(short token)
             {
                 var f = Interlocked.Exchange(ref factory, null);
-                if (f == null) throw new InvalidOperationException("Can't call twice.");
+                if (f != null)
+                {
+                    task = f();
+                    awaiter = task.GetAwaiter();
+                }
 
-                task = f();
-                awaiter = task.GetAwaiter();
                 return task.Status;
             }
 


### PR DESCRIPTION
Subject:
``` csharp
private void Start()
{
    UniTask task = UniTask.Defer(Hoge);
    task.Forget(); //or await task etc..
}

private async UniTask<int> Hoge()
{
    await UniTask.Delay(1000);
    UnityEngine.Debug.Log("Hoge");
    return 99;
}
```

Expected result: "Hoge" should be printed in Unity console
Actual result: throws InvalidOperationException("Can't call twice.");

Could be produced in code something like
``` csharp
var task = UniTask.Defer(Hoge); //UniTask<int> task
UniTask.WhenAll(task, task)
```