### PR TITLE
Improve compilation stability

### DIFF
--- a/src/UniTask/Assets/Plugins/UniTask/Editor/UniTask.Editor.asmdef
+++ b/src/UniTask/Assets/Plugins/UniTask/Editor/UniTask.Editor.asmdef
@@ -8,7 +8,7 @@
     ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
-    "overrideReferences": false,
+    "overrideReferences": true,
     "precompiledReferences": [],
     "autoReferenced": false,
     "defineConstraints": [],

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/External/Addressables/UniTask.Addressables.asmdef
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/External/Addressables/UniTask.Addressables.asmdef
@@ -7,7 +7,7 @@
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
-    "overrideReferences": false,
+    "overrideReferences": true,
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/External/DOTween/UniTask.DOTween.asmdef
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/External/DOTween/UniTask.DOTween.asmdef
@@ -7,8 +7,10 @@
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
-    "overrideReferences": false,
-    "precompiledReferences": [],
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "DOTween.dll"
+    ],
     "autoReferenced": true,
     "defineConstraints": [],
     "versionDefines": [

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/External/TextMeshPro/UniTask.TextMeshPro.asmdef
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/External/TextMeshPro/UniTask.TextMeshPro.asmdef
@@ -7,7 +7,7 @@
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
-    "overrideReferences": false,
+    "overrideReferences": true,
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/Linq/UniTask.Linq.asmdef
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/Linq/UniTask.Linq.asmdef
@@ -6,7 +6,7 @@
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
-    "overrideReferences": false,
+    "overrideReferences": true,
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTask.asmdef
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTask.asmdef
@@ -5,7 +5,7 @@
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
-    "overrideReferences": false,
+    "overrideReferences": true,
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],

--- a/src/UniTask/Assets/Plugins/UniTask/package.json
+++ b/src/UniTask/Assets/Plugins/UniTask/package.json
@@ -7,5 +7,11 @@
     "keywords": [ "async/await", "async", "Task", "UniTask" ],
     "license": "MIT",
     "category": "Task",
-    "dependencies": {}
+    "dependencies": {
+        "com.unity.ugui": "1.0.0",
+        "com.unity.modules.particlesystem": "1.0.0",
+        "com.unity.modules.physics": "1.0.0",
+        "com.unity.modules.physics2d": "1.0.0",
+        "com.unity.modules.unitywebrequest": "1.0.0"
+    }
 }


### PR DESCRIPTION
- Fix #222
- Fix failing to compile when there are types with same name but in different pre-compiled assembly