### PR TITLE
chore: new docker image to build

### DIFF
--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v2
       # Execute scripts: RuntimeUnitTestToolkit
       - name: Build UnitTest(Linux64, mono)
-        uses: webbertakken/unity-builder@v2.0-alpha-6
+        uses: game-ci/unity-builder@v2.0-alpha-6
         env:
           UNITY_LICENSE: ${{ secrets[matrix.license] }}
         with:
@@ -57,7 +57,7 @@ jobs:
 
       # Execute scripts: Export Package
       - name: Export unitypackage
-        uses: webbertakken/unity-builder@v2.0-alpha-6
+        uses: game-ci/unity-builder@v2.0-alpha-6
         env:
           UNITY_LICENSE: ${{ secrets[matrix.license] }}
         with:

--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -37,8 +37,8 @@ jobs:
             license: UNITY_2020_1
     runs-on: ubuntu-latest
     container:
-      # with linux-il2cpp. image from https://hub.docker.com/r/gableroux/unity3d/tags
-      image: gableroux/unity3d:${{ matrix.unity }}-linux-il2cpp
+      # with linux-il2cpp. image from https://hub.docker.com/r/unityci/editor/tags
+      image: unityci/editor:${{ matrix.unity }}-linux-il2cpp-0
     steps:
       # Ubuntu 18.04 git is too old, use ppa latest git.
       - run: |

--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -49,18 +49,18 @@ jobs:
         env:
           UNITY_LICENSE: ${{ secrets[matrix.license] }}
       - name: Activate Unity, always returns a success. But if a subsequent run fails, the activation may have failed(if succeeded, shows `Next license update check is after` and not shows other message(like GUID != GUID). If fails not). In that case, upload the artifact's .alf file to https://license.unity3d.com/manual to get the .ulf file and set it to secrets.
-        run: /opt/Unity/Editor/Unity -quit -batchmode -nographics -silent-crashes -logFile -manualLicenseFile .Unity.ulf || exit 0
+        run: unity-editor -quit -batchmode -nographics -silent-crashes -logFile -manualLicenseFile .Unity.ulf || exit 0
 
       # Execute scripts: RuntimeUnitTestToolkit
       - name: Build UnitTest(Linux64, mono)
-        run: /opt/Unity/Editor/Unity -quit -batchmode -nographics -silent-crashes -logFile -projectPath . -executeMethod UnitTestBuilder.BuildUnitTest /headless /ScriptBackend mono /BuildTarget StandaloneLinux64
+        run: unity-editor -quit -batchmode -nographics -silent-crashes -logFile -projectPath . -executeMethod UnitTestBuilder.BuildUnitTest /headless /ScriptBackend mono /BuildTarget StandaloneLinux64
         working-directory: src/UniTask
       - name: Execute UnitTest
         run: ./src/UniTask/bin/UnitTest/StandaloneLinux64_Mono2x/test
 
       # Execute scripts: Export Package
       - name: Export unitypackage
-        run: /opt/Unity/Editor/Unity -quit -batchmode -nographics -silent-crashes -logFile -projectPath . -executeMethod PackageExporter.Export
+        run: unity-editor -quit -batchmode -nographics -silent-crashes -logFile -projectPath . -executeMethod PackageExporter.Export
         working-directory: src/UniTask
 
       - name: check all .meta is commited

--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -29,11 +29,11 @@ jobs:
     if: "!(contains(github.event.head_commit.message, '[skip ci]') || contains(github.event.head_commit.message, '[ci skip]')) && ((github.event_name == 'push' && github.repository_owner == 'Cysharp') || startsWith(github.event.pull_request.head.label, 'Cysharp:'))"
     strategy:
       matrix:
-        unity: ["2019.3.9f1", "2020.1.0b5"]
+        unity: ["2019.3.9f1", "2020.1.12f1"]
         include:
           - unity: 2019.3.9f1
             license: UNITY_2019_3
-          - unity: 2020.1.0b5
+          - unity: 2020.1.12f1
             license: UNITY_2020_1
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -29,39 +29,43 @@ jobs:
     if: "!(contains(github.event.head_commit.message, '[skip ci]') || contains(github.event.head_commit.message, '[ci skip]')) && ((github.event_name == 'push' && github.repository_owner == 'Cysharp') || startsWith(github.event.pull_request.head.label, 'Cysharp:'))"
     strategy:
       matrix:
-        unity: ["2019.3.9f1", "2020.1.12f1"]
+        unity: ["2019.3.9f1", "2019.4.13f1", "2020.1.12f1"]
         include:
           - unity: 2019.3.9f1
-            license: UNITY_2019_3
+            license: UNITY_LICENSE_2019
+          - unity: 2019.4.13f1
+            license: UNITY_LICENSE_2019
           - unity: 2020.1.12f1
-            license: UNITY_2020_1
+            license: UNITY_LICENSE_2020
     runs-on: ubuntu-latest
-    container:
-      # with linux-il2cpp. image from https://hub.docker.com/r/unityci/editor/tags
-      image: unityci/editor:${{ matrix.unity }}-linux-il2cpp-0
     steps:
-      # Ubuntu 18.04 git is too old, use ppa latest git.
-      - run: |
-          apt-get update && apt-get install --no-install-recommends -y software-properties-common && add-apt-repository -y ppa:git-core/ppa
-          apt-get update && apt-get install --no-install-recommends -y git
       - uses: actions/checkout@v2
-      - run: echo -n "$UNITY_LICENSE" >> .Unity.ulf
-        env:
-          UNITY_LICENSE: ${{ secrets[matrix.license] }}
-      - name: Activate Unity, always returns a success. But if a subsequent run fails, the activation may have failed(if succeeded, shows `Next license update check is after` and not shows other message(like GUID != GUID). If fails not). In that case, upload the artifact's .alf file to https://license.unity3d.com/manual to get the .ulf file and set it to secrets.
-        run: unity-editor -quit -batchmode -nographics -silent-crashes -logFile -manualLicenseFile .Unity.ulf || exit 0
-
       # Execute scripts: RuntimeUnitTestToolkit
       - name: Build UnitTest(Linux64, mono)
-        run: unity-editor -quit -batchmode -nographics -silent-crashes -logFile -projectPath . -executeMethod UnitTestBuilder.BuildUnitTest /headless /ScriptBackend mono /BuildTarget StandaloneLinux64
-        working-directory: src/UniTask
+        uses: webbertakken/unity-builder@v2.0-alpha-6
+        env:
+          UNITY_LICENSE: ${{ secrets[matrix.license] }}
+        with:
+          projectPath: src/UniTask
+          unityVersion: ${{ matrix.unity }}
+          targetPlatform: StandaloneLinux64
+          buildMethod: UnitTestBuilder.BuildUnitTest
+          customParameters: /headless /ScriptBackend mono
+          versioning: None
       - name: Execute UnitTest
         run: ./src/UniTask/bin/UnitTest/StandaloneLinux64_Mono2x/test
 
       # Execute scripts: Export Package
       - name: Export unitypackage
-        run: unity-editor -quit -batchmode -nographics -silent-crashes -logFile -projectPath . -executeMethod PackageExporter.Export
-        working-directory: src/UniTask
+        uses: webbertakken/unity-builder@v2.0-alpha-6
+        env:
+          UNITY_LICENSE: ${{ secrets[matrix.license] }}
+        with:
+          projectPath: src/UniTask
+          unityVersion: ${{ matrix.unity }}
+          targetPlatform: StandaloneLinux64
+          buildMethod: PackageExporter.Export
+          versioning: None
 
       - name: check all .meta is commited
         run: |
@@ -76,5 +80,5 @@ jobs:
       # Store artifacts.
       - uses: actions/upload-artifact@v2
         with:
-          name: UniTask.unitypackage.zip
+          name: UniTask.unitypackage-${{ matrix.unity }}.zip
           path: ./src/UniTask/*.unitypackage

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -101,7 +101,7 @@ jobs:
       - uses: actions/checkout@v2
       # Execute scripts: Export Package
       - name: Export unitypackage
-        uses: webbertakken/unity-builder@v2.0-alpha-6
+        uses: game-ci/unity-builder@v2.0-alpha-6
         env:
           UNITY_LICENSE: ${{ secrets[matrix.license] }}
         with:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -94,30 +94,22 @@ jobs:
         unity: ["2019.3.9f1"]
         include:
           - unity: 2019.3.9f1
-            license: UNITY_2019_3
+            license: UNITY_LICENSE_2019
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    container:
-      # with linux-il2cpp. image from https://hub.docker.com/r/gableroux/unity3d/tags
-      image: gableroux/unity3d:${{ matrix.unity }}-linux-il2cpp
     steps:
-      # Ubuntu 18.04 git is too old, use ppa latest git.
-      - run: |
-          apt-get update && apt-get install --no-install-recommends -y software-properties-common && add-apt-repository -y ppa:git-core/ppa
-          apt-get update && apt-get install --no-install-recommends -y git
       - uses: actions/checkout@v2
-        with:
-          ref: ${{ needs.update-packagejson.outputs.sha }}
-      # activate Unity from manual license file(ulf)
-      - run: echo -n "$UNITY_LICENSE" >> .Unity.ulf
-        env:
-          UNITY_LICENSE: ${{ secrets[matrix.license] }}
-      - run: /opt/Unity/Editor/Unity -quit -batchmode -nographics -silent-crashes -logFile -manualLicenseFile .Unity.ulf || exit 0
-
       # Execute scripts: Export Package
       - name: Export unitypackage
-        run: /opt/Unity/Editor/Unity -quit -batchmode -nographics -silent-crashes -logFile -projectPath . -executeMethod PackageExporter.Export
-        working-directory: src/UniTask
+        uses: webbertakken/unity-builder@v2.0-alpha-6
+        env:
+          UNITY_LICENSE: ${{ secrets[matrix.license] }}
+        with:
+          projectPath: src/UniTask
+          unityVersion: ${{ matrix.unity }}
+          targetPlatform: StandaloneLinux64
+          buildMethod: PackageExporter.Export
+          versioning: None
 
       - name: check all .meta is commited
         run: |


### PR DESCRIPTION
## TL;DR

* change: ci image update to unityci/editor.
* change: unity ci to build with actions.

## Summary

* gableroux/unity3d is deprecated and moved to unityci/editor.
* Unity License Activation / Build is handle with actions `game-ci/unity-builder`, no more direct batch mode call.

## Effect

* ALF/ULF License is not compatible with gableroux/unity3d, new ULF is used in unityci/editor.
