### PR TITLE
feat: ✨ add UniTask.DelaySeconds

### DIFF
--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTask.Delay.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTask.Delay.cs
@@ -135,6 +135,18 @@ namespace Cysharp.Threading.Tasks
             return Delay(delayTimeSpan, delayType, delayTiming, cancellationToken);
         }
 
+        public static UniTask DelaySeconds(double secondsDelay, bool ignoreTimeScale = false, PlayerLoopTiming delayTiming = PlayerLoopTiming.Update, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var delayTimeSpan = TimeSpan.FromSeconds(secondsDelay);
+            return Delay(delayTimeSpan, ignoreTimeScale, delayTiming, cancellationToken);
+        }
+
+        public static UniTask DelaySeconds(double secondsDelay, DelayType delayType, PlayerLoopTiming delayTiming = PlayerLoopTiming.Update, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var delayTimeSpan = TimeSpan.FromSeconds(secondsDelay);
+            return Delay(delayTimeSpan, delayType, delayTiming, cancellationToken);
+        }
+
         public static UniTask Delay(TimeSpan delayTimeSpan, DelayType delayType, PlayerLoopTiming delayTiming = PlayerLoopTiming.Update, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (delayTimeSpan < TimeSpan.Zero)


### PR DESCRIPTION
I'm used to seconds rather than milliseconds (and I'm sure others are too), so I often write `UniTask.Delay(TimeSpan.FromSeconds(seconds))`, but it takes a little work, so I created a method to write it as `UniTask.DelaySeconds(seconds)`.
Please consider adding this feature🙃