### PR TITLE
[DoTween]: fix "AwaitFor~" extensions ignore original callback

### DIFF
--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/External/DOTween/DOTweenAsyncExtensions.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/External/DOTween/DOTweenAsyncExtensions.cs
@@ -16,14 +16,14 @@ namespace Cysharp.Threading.Tasks
         Kill,
         KillWithCompleteCallback,
         Complete,
-        CompleteWithSeqeunceCallback,
+        CompleteWithSequenceCallback,
         CancelAwait,
 
         // AndCancelAwait
         KillAndCancelAwait,
         KillWithCompleteCallbackAndCancelAwait,
         CompleteAndCancelAwait,
-        CompleteWithSeqeunceCallbackAndCancelAwait
+        CompleteWithSequenceCallbackAndCancelAwait
     }
 
     public static class DOTweenAsyncExtensions
@@ -238,7 +238,7 @@ namespace Cysharp.Threading.Tasks
                     if (this.cancelBehaviour == TweenCancelBehaviour.KillAndCancelAwait
                         || this.cancelBehaviour == TweenCancelBehaviour.KillWithCompleteCallbackAndCancelAwait
                         || this.cancelBehaviour == TweenCancelBehaviour.CompleteAndCancelAwait
-                        || this.cancelBehaviour == TweenCancelBehaviour.CompleteWithSeqeunceCallbackAndCancelAwait
+                        || this.cancelBehaviour == TweenCancelBehaviour.CompleteWithSequenceCallbackAndCancelAwait
                         || this.cancelBehaviour == TweenCancelBehaviour.CancelAwait)
                     {
                         canceled = true;
@@ -288,10 +288,10 @@ namespace Cysharp.Threading.Tasks
                         this.canceled = true;
                         this.tween.Complete(false);
                         break;
-                    case TweenCancelBehaviour.CompleteWithSeqeunceCallback:
+                    case TweenCancelBehaviour.CompleteWithSequenceCallback:
                         this.tween.Complete(true);
                         break;
-                    case TweenCancelBehaviour.CompleteWithSeqeunceCallbackAndCancelAwait:
+                    case TweenCancelBehaviour.CompleteWithSequenceCallbackAndCancelAwait:
                         this.canceled = true;
                         this.tween.Complete(true);
                         break;
@@ -350,10 +350,10 @@ namespace Cysharp.Threading.Tasks
                     case TweenCancelBehaviour.CompleteAndCancelAwait:
                         tween.Complete(false);
                         break;
-                    case TweenCancelBehaviour.CompleteWithSeqeunceCallback:
+                    case TweenCancelBehaviour.CompleteWithSequenceCallback:
                         tween.Complete(true);
                         break;
-                    case TweenCancelBehaviour.CompleteWithSeqeunceCallbackAndCancelAwait:
+                    case TweenCancelBehaviour.CompleteWithSequenceCallbackAndCancelAwait:
                         tween.Complete(true);
                         break;
                     case TweenCancelBehaviour.CancelAwait:


### PR DESCRIPTION
Currently, `AwaitFor~` extensions overwrite callback of `Tween` and ignore them. 
It is fine for most of case (because there is no reason to rely on callback if await them) but is problem when I use `DoTweenAnimation` (DoTweenPro feature).  

With `DoTweenAnimation`, callback for each event can be registered in inspector.  
When I await them with `AwaitFor`, those callbacks are not called.

![image](https://user-images.githubusercontent.com/22076358/117528634-1697a600-b00e-11eb-85dc-3873a63aa892.png)

So I did something like `originalUpdateAction` does.