### PR TITLE
Add WhenAny(UniTask, UniTask) and WhenAll(UniTask, UniTask) overloads with 2-15 arguments

### DIFF
--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTask.WhenAll.Generated.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTask.WhenAll.Generated.cs
@@ -5007,5 +5007,352 @@ namespace Cysharp.Threading.Tasks
                 core.OnCompleted(continuation, state, token);
             }
         }
+
+        public static UniTask WhenAll(UniTask task1, UniTask task2)
+        {
+            return new UniTask(new WhenAllPromise(task1, task2), 0);
+        }
+
+        public static UniTask WhenAll(UniTask task1, UniTask task2, UniTask task3)
+        {
+            return new UniTask(new WhenAllPromise(task1, task2, task3), 0);
+        }
+
+        public static UniTask WhenAll(UniTask task1, UniTask task2, UniTask task3, UniTask task4)
+        {
+            return new UniTask(new WhenAllPromise(task1, task2, task3, task4), 0);
+        }
+
+        public static UniTask WhenAll(UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5)
+        {
+            return new UniTask(new WhenAllPromise(task1, task2, task3, task4, task5), 0);
+        }
+
+        public static UniTask WhenAll(UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5, UniTask task6)
+        {
+            return new UniTask(new WhenAllPromise(task1, task2, task3, task4, task5, task6), 0);
+        }
+
+        public static UniTask WhenAll(UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5, UniTask task6, UniTask task7)
+        {
+            return new UniTask(new WhenAllPromise(task1, task2, task3, task4, task5, task6, task7), 0);
+        }
+
+        public static UniTask WhenAll(UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5, UniTask task6, UniTask task7, UniTask task8)
+        {
+            return new UniTask(new WhenAllPromise(task1, task2, task3, task4, task5, task6, task7, task8), 0);
+        }
+
+        public static UniTask WhenAll(UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5, UniTask task6, UniTask task7, UniTask task8, UniTask task9)
+        {
+            return new UniTask(new WhenAllPromise(task1, task2, task3, task4, task5, task6, task7, task8, task9), 0);
+        }
+
+        public static UniTask WhenAll(UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5, UniTask task6, UniTask task7, UniTask task8, UniTask task9, UniTask task10)
+        {
+            return new UniTask(new WhenAllPromise(task1, task2, task3, task4, task5, task6, task7, task8, task9, task10), 0);
+        }
+
+        public static UniTask WhenAll(UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5, UniTask task6, UniTask task7, UniTask task8, UniTask task9, UniTask task10, UniTask task11)
+        {
+            return new UniTask(new WhenAllPromise(task1, task2, task3, task4, task5, task6, task7, task8, task9, task10, task11), 0);
+        }
+
+        public static UniTask WhenAll(UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5, UniTask task6, UniTask task7, UniTask task8, UniTask task9, UniTask task10, UniTask task11, UniTask task12)
+        {
+            return new UniTask(new WhenAllPromise(task1, task2, task3, task4, task5, task6, task7, task8, task9, task10, task11, task12), 0);
+        }
+
+        public static UniTask WhenAll(UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5, UniTask task6, UniTask task7, UniTask task8, UniTask task9, UniTask task10, UniTask task11, UniTask task12, UniTask task13)
+        {
+            return new UniTask(new WhenAllPromise(task1, task2, task3, task4, task5, task6, task7, task8, task9, task10, task11, task12, task13), 0);
+        }
+
+        public static UniTask WhenAll(UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5, UniTask task6, UniTask task7, UniTask task8, UniTask task9, UniTask task10, UniTask task11, UniTask task12, UniTask task13, UniTask task14)
+        {
+            return new UniTask(new WhenAllPromise(task1, task2, task3, task4, task5, task6, task7, task8, task9, task10, task11, task12, task13, task14), 0);
+        }
+
+        public static UniTask WhenAll(UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5, UniTask task6, UniTask task7, UniTask task8, UniTask task9, UniTask task10, UniTask task11, UniTask task12, UniTask task13, UniTask task14, UniTask task15)
+        {
+            return new UniTask(new WhenAllPromise(task1, task2, task3, task4, task5, task6, task7, task8, task9, task10, task11, task12, task13, task14, task15), 0);
+        }
+
+        sealed partial class WhenAllPromise : IUniTaskSource
+        {
+            public WhenAllPromise(UniTask task1, UniTask task2)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                this.tasksLength = 2;
+                this.completeCount = 0;
+
+                StartTask(task1);
+                StartTask(task2);
+            }
+
+            public WhenAllPromise(UniTask task1, UniTask task2, UniTask task3)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                this.tasksLength = 3;
+                this.completeCount = 0;
+
+                StartTask(task1);
+                StartTask(task2);
+                StartTask(task3);
+            }
+
+            public WhenAllPromise(UniTask task1, UniTask task2, UniTask task3, UniTask task4)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                this.tasksLength = 4;
+                this.completeCount = 0;
+
+                StartTask(task1);
+                StartTask(task2);
+                StartTask(task3);
+                StartTask(task4);
+            }
+
+            public WhenAllPromise(UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                this.tasksLength = 5;
+                this.completeCount = 0;
+
+                StartTask(task1);
+                StartTask(task2);
+                StartTask(task3);
+                StartTask(task4);
+                StartTask(task5);
+            }
+
+            public WhenAllPromise(UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5, UniTask task6)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                this.tasksLength = 6;
+                this.completeCount = 0;
+
+                StartTask(task1);
+                StartTask(task2);
+                StartTask(task3);
+                StartTask(task4);
+                StartTask(task5);
+                StartTask(task6);
+            }
+
+            public WhenAllPromise(UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5, UniTask task6, UniTask task7)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                this.tasksLength = 7;
+                this.completeCount = 0;
+
+                StartTask(task1);
+                StartTask(task2);
+                StartTask(task3);
+                StartTask(task4);
+                StartTask(task5);
+                StartTask(task6);
+                StartTask(task7);
+            }
+
+            public WhenAllPromise(UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5, UniTask task6, UniTask task7, UniTask task8)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                this.tasksLength = 8;
+                this.completeCount = 0;
+
+                StartTask(task1);
+                StartTask(task2);
+                StartTask(task3);
+                StartTask(task4);
+                StartTask(task5);
+                StartTask(task6);
+                StartTask(task7);
+                StartTask(task8);
+            }
+
+            public WhenAllPromise(UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5, UniTask task6, UniTask task7, UniTask task8, UniTask task9)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                this.tasksLength = 9;
+                this.completeCount = 0;
+
+                StartTask(task1);
+                StartTask(task2);
+                StartTask(task3);
+                StartTask(task4);
+                StartTask(task5);
+                StartTask(task6);
+                StartTask(task7);
+                StartTask(task8);
+                StartTask(task9);
+            }
+
+            public WhenAllPromise(UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5, UniTask task6, UniTask task7, UniTask task8, UniTask task9, UniTask task10)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                this.tasksLength = 10;
+                this.completeCount = 0;
+
+                StartTask(task1);
+                StartTask(task2);
+                StartTask(task3);
+                StartTask(task4);
+                StartTask(task5);
+                StartTask(task6);
+                StartTask(task7);
+                StartTask(task8);
+                StartTask(task9);
+                StartTask(task10);
+            }
+
+            public WhenAllPromise(UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5, UniTask task6, UniTask task7, UniTask task8, UniTask task9, UniTask task10, UniTask task11)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                this.tasksLength = 11;
+                this.completeCount = 0;
+
+                StartTask(task1);
+                StartTask(task2);
+                StartTask(task3);
+                StartTask(task4);
+                StartTask(task5);
+                StartTask(task6);
+                StartTask(task7);
+                StartTask(task8);
+                StartTask(task9);
+                StartTask(task10);
+                StartTask(task11);
+            }
+
+            public WhenAllPromise(UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5, UniTask task6, UniTask task7, UniTask task8, UniTask task9, UniTask task10, UniTask task11, UniTask task12)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                this.tasksLength = 12;
+                this.completeCount = 0;
+
+                StartTask(task1);
+                StartTask(task2);
+                StartTask(task3);
+                StartTask(task4);
+                StartTask(task5);
+                StartTask(task6);
+                StartTask(task7);
+                StartTask(task8);
+                StartTask(task9);
+                StartTask(task10);
+                StartTask(task11);
+                StartTask(task12);
+            }
+
+            public WhenAllPromise(UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5, UniTask task6, UniTask task7, UniTask task8, UniTask task9, UniTask task10, UniTask task11, UniTask task12, UniTask task13)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                this.tasksLength = 13;
+                this.completeCount = 0;
+
+                StartTask(task1);
+                StartTask(task2);
+                StartTask(task3);
+                StartTask(task4);
+                StartTask(task5);
+                StartTask(task6);
+                StartTask(task7);
+                StartTask(task8);
+                StartTask(task9);
+                StartTask(task10);
+                StartTask(task11);
+                StartTask(task12);
+                StartTask(task13);
+            }
+
+            public WhenAllPromise(UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5, UniTask task6, UniTask task7, UniTask task8, UniTask task9, UniTask task10, UniTask task11, UniTask task12, UniTask task13, UniTask task14)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                this.tasksLength = 14;
+                this.completeCount = 0;
+
+                StartTask(task1);
+                StartTask(task2);
+                StartTask(task3);
+                StartTask(task4);
+                StartTask(task5);
+                StartTask(task6);
+                StartTask(task7);
+                StartTask(task8);
+                StartTask(task9);
+                StartTask(task10);
+                StartTask(task11);
+                StartTask(task12);
+                StartTask(task13);
+                StartTask(task14);
+            }
+
+            public WhenAllPromise(UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5, UniTask task6, UniTask task7, UniTask task8, UniTask task9, UniTask task10, UniTask task11, UniTask task12, UniTask task13, UniTask task14, UniTask task15)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                this.tasksLength = 15;
+                this.completeCount = 0;
+
+                StartTask(task1);
+                StartTask(task2);
+                StartTask(task3);
+                StartTask(task4);
+                StartTask(task5);
+                StartTask(task6);
+                StartTask(task7);
+                StartTask(task8);
+                StartTask(task9);
+                StartTask(task10);
+                StartTask(task11);
+                StartTask(task12);
+                StartTask(task13);
+                StartTask(task14);
+                StartTask(task15);
+            }
+
+            private void StartTask(UniTask task)
+            {
+                UniTask.Awaiter awaiter;
+                try
+                {
+                    awaiter = task.GetAwaiter();
+                }
+                catch (Exception ex)
+                {
+                    core.TrySetException(ex);
+                    return;
+                }
+
+                if (awaiter.IsCompleted)
+                {
+                    TryInvokeContinuation(this, awaiter);
+                }
+                else
+                {
+                    awaiter.SourceOnCompleted(state =>
+                    {
+                        using (var t = (StateTuple<WhenAllPromise, UniTask.Awaiter>)state)
+                        {
+                            TryInvokeContinuation(t.Item1, t.Item2);
+                        }
+                    }, StateTuple.Create(this, awaiter));
+                }
+            }
+        }
     }
 }

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTask.WhenAll.Generated.tt
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTask.WhenAll.Generated.tt
@@ -118,5 +118,64 @@ namespace Cysharp.Threading.Tasks
             }
         }
 <# } #>
+
+<# for(var i = 2; i <= 15; i++ ) {
+    var range = Enumerable.Range(1, i);
+    var args = string.Join(", ", range.Select(x => $"UniTask task{x}"));
+    var targs = string.Join(", ", range.Select(x => $"task{x}"));
+#>
+        public static UniTask WhenAll(<#= args #>)
+        {
+            return new UniTask(new WhenAllPromise(<#= targs #>), 0);
+        }
+
+<# } #>
+        sealed partial class WhenAllPromise : IUniTaskSource
+        {
+<# for(var i = 2; i <= 15; i++ ) {
+    var range = Enumerable.Range(1, i);
+    var args = string.Join(", ", range.Select(x => $"UniTask task{x}"));
+    var startTasks = string.Join("\n", range.Select(x => $"{new string(' ', 16)}StartTask(task{x});"));
+#>
+            public WhenAllPromise(<#= args #>)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                this.tasksLength = <#= i #>;
+                this.completeCount = 0;
+
+<#= startTasks #>
+            }
+
+<# } #>
+            private void StartTask(UniTask task)
+            {
+                UniTask.Awaiter awaiter;
+                try
+                {
+                    awaiter = task.GetAwaiter();
+                }
+                catch (Exception ex)
+                {
+                    core.TrySetException(ex);
+                    return;
+                }
+
+                if (awaiter.IsCompleted)
+                {
+                    TryInvokeContinuation(this, awaiter);
+                }
+                else
+                {
+                    awaiter.SourceOnCompleted(state =>
+                    {
+                        using (var t = (StateTuple<WhenAllPromise, UniTask.Awaiter>)state)
+                        {
+                            TryInvokeContinuation(t.Item1, t.Item2);
+                        }
+                    }, StateTuple.Create(this, awaiter));
+                }
+            }
+        }
     }
 }

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTask.WhenAll.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTask.WhenAll.cs
@@ -144,7 +144,7 @@ namespace Cysharp.Threading.Tasks
             }
         }
 
-        sealed class WhenAllPromise : IUniTaskSource
+        sealed partial class WhenAllPromise : IUniTaskSource
         {
             int completeCount;
             int tasksLength;

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTask.WhenAny.Generated.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTask.WhenAny.Generated.cs
@@ -5056,5 +5056,310 @@ namespace Cysharp.Threading.Tasks
             }
         }
 
+        public static UniTask<int> WhenAny(UniTask task1, UniTask task2)
+        {
+            return new UniTask<int>(new WhenAnyPromise(task1, task2), 0);
+        }
+
+        public static UniTask<int> WhenAny(UniTask task1, UniTask task2, UniTask task3)
+        {
+            return new UniTask<int>(new WhenAnyPromise(task1, task2, task3), 0);
+        }
+
+        public static UniTask<int> WhenAny(UniTask task1, UniTask task2, UniTask task3, UniTask task4)
+        {
+            return new UniTask<int>(new WhenAnyPromise(task1, task2, task3, task4), 0);
+        }
+
+        public static UniTask<int> WhenAny(UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5)
+        {
+            return new UniTask<int>(new WhenAnyPromise(task1, task2, task3, task4, task5), 0);
+        }
+
+        public static UniTask<int> WhenAny(UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5, UniTask task6)
+        {
+            return new UniTask<int>(new WhenAnyPromise(task1, task2, task3, task4, task5, task6), 0);
+        }
+
+        public static UniTask<int> WhenAny(UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5, UniTask task6, UniTask task7)
+        {
+            return new UniTask<int>(new WhenAnyPromise(task1, task2, task3, task4, task5, task6, task7), 0);
+        }
+
+        public static UniTask<int> WhenAny(UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5, UniTask task6, UniTask task7, UniTask task8)
+        {
+            return new UniTask<int>(new WhenAnyPromise(task1, task2, task3, task4, task5, task6, task7, task8), 0);
+        }
+
+        public static UniTask<int> WhenAny(UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5, UniTask task6, UniTask task7, UniTask task8, UniTask task9)
+        {
+            return new UniTask<int>(new WhenAnyPromise(task1, task2, task3, task4, task5, task6, task7, task8, task9), 0);
+        }
+
+        public static UniTask<int> WhenAny(UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5, UniTask task6, UniTask task7, UniTask task8, UniTask task9, UniTask task10)
+        {
+            return new UniTask<int>(new WhenAnyPromise(task1, task2, task3, task4, task5, task6, task7, task8, task9, task10), 0);
+        }
+
+        public static UniTask<int> WhenAny(UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5, UniTask task6, UniTask task7, UniTask task8, UniTask task9, UniTask task10, UniTask task11)
+        {
+            return new UniTask<int>(new WhenAnyPromise(task1, task2, task3, task4, task5, task6, task7, task8, task9, task10, task11), 0);
+        }
+
+        public static UniTask<int> WhenAny(UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5, UniTask task6, UniTask task7, UniTask task8, UniTask task9, UniTask task10, UniTask task11, UniTask task12)
+        {
+            return new UniTask<int>(new WhenAnyPromise(task1, task2, task3, task4, task5, task6, task7, task8, task9, task10, task11, task12), 0);
+        }
+
+        public static UniTask<int> WhenAny(UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5, UniTask task6, UniTask task7, UniTask task8, UniTask task9, UniTask task10, UniTask task11, UniTask task12, UniTask task13)
+        {
+            return new UniTask<int>(new WhenAnyPromise(task1, task2, task3, task4, task5, task6, task7, task8, task9, task10, task11, task12, task13), 0);
+        }
+
+        public static UniTask<int> WhenAny(UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5, UniTask task6, UniTask task7, UniTask task8, UniTask task9, UniTask task10, UniTask task11, UniTask task12, UniTask task13, UniTask task14)
+        {
+            return new UniTask<int>(new WhenAnyPromise(task1, task2, task3, task4, task5, task6, task7, task8, task9, task10, task11, task12, task13, task14), 0);
+        }
+
+        public static UniTask<int> WhenAny(UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5, UniTask task6, UniTask task7, UniTask task8, UniTask task9, UniTask task10, UniTask task11, UniTask task12, UniTask task13, UniTask task14, UniTask task15)
+        {
+            return new UniTask<int>(new WhenAnyPromise(task1, task2, task3, task4, task5, task6, task7, task8, task9, task10, task11, task12, task13, task14, task15), 0);
+        }
+
+        sealed partial class WhenAnyPromise : IUniTaskSource<int>
+        {
+            public WhenAnyPromise(UniTask task1, UniTask task2)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                StartTask(task1, 0);
+                StartTask(task2, 1);
+            }
+
+            public WhenAnyPromise(UniTask task1, UniTask task2, UniTask task3)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                StartTask(task1, 0);
+                StartTask(task2, 1);
+                StartTask(task3, 2);
+            }
+
+            public WhenAnyPromise(UniTask task1, UniTask task2, UniTask task3, UniTask task4)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                StartTask(task1, 0);
+                StartTask(task2, 1);
+                StartTask(task3, 2);
+                StartTask(task4, 3);
+            }
+
+            public WhenAnyPromise(UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                StartTask(task1, 0);
+                StartTask(task2, 1);
+                StartTask(task3, 2);
+                StartTask(task4, 3);
+                StartTask(task5, 4);
+            }
+
+            public WhenAnyPromise(UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5, UniTask task6)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                StartTask(task1, 0);
+                StartTask(task2, 1);
+                StartTask(task3, 2);
+                StartTask(task4, 3);
+                StartTask(task5, 4);
+                StartTask(task6, 5);
+            }
+
+            public WhenAnyPromise(UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5, UniTask task6, UniTask task7)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                StartTask(task1, 0);
+                StartTask(task2, 1);
+                StartTask(task3, 2);
+                StartTask(task4, 3);
+                StartTask(task5, 4);
+                StartTask(task6, 5);
+                StartTask(task7, 6);
+            }
+
+            public WhenAnyPromise(UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5, UniTask task6, UniTask task7, UniTask task8)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                StartTask(task1, 0);
+                StartTask(task2, 1);
+                StartTask(task3, 2);
+                StartTask(task4, 3);
+                StartTask(task5, 4);
+                StartTask(task6, 5);
+                StartTask(task7, 6);
+                StartTask(task8, 7);
+            }
+
+            public WhenAnyPromise(UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5, UniTask task6, UniTask task7, UniTask task8, UniTask task9)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                StartTask(task1, 0);
+                StartTask(task2, 1);
+                StartTask(task3, 2);
+                StartTask(task4, 3);
+                StartTask(task5, 4);
+                StartTask(task6, 5);
+                StartTask(task7, 6);
+                StartTask(task8, 7);
+                StartTask(task9, 8);
+            }
+
+            public WhenAnyPromise(UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5, UniTask task6, UniTask task7, UniTask task8, UniTask task9, UniTask task10)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                StartTask(task1, 0);
+                StartTask(task2, 1);
+                StartTask(task3, 2);
+                StartTask(task4, 3);
+                StartTask(task5, 4);
+                StartTask(task6, 5);
+                StartTask(task7, 6);
+                StartTask(task8, 7);
+                StartTask(task9, 8);
+                StartTask(task10, 9);
+            }
+
+            public WhenAnyPromise(UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5, UniTask task6, UniTask task7, UniTask task8, UniTask task9, UniTask task10, UniTask task11)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                StartTask(task1, 0);
+                StartTask(task2, 1);
+                StartTask(task3, 2);
+                StartTask(task4, 3);
+                StartTask(task5, 4);
+                StartTask(task6, 5);
+                StartTask(task7, 6);
+                StartTask(task8, 7);
+                StartTask(task9, 8);
+                StartTask(task10, 9);
+                StartTask(task11, 10);
+            }
+
+            public WhenAnyPromise(UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5, UniTask task6, UniTask task7, UniTask task8, UniTask task9, UniTask task10, UniTask task11, UniTask task12)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                StartTask(task1, 0);
+                StartTask(task2, 1);
+                StartTask(task3, 2);
+                StartTask(task4, 3);
+                StartTask(task5, 4);
+                StartTask(task6, 5);
+                StartTask(task7, 6);
+                StartTask(task8, 7);
+                StartTask(task9, 8);
+                StartTask(task10, 9);
+                StartTask(task11, 10);
+                StartTask(task12, 11);
+            }
+
+            public WhenAnyPromise(UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5, UniTask task6, UniTask task7, UniTask task8, UniTask task9, UniTask task10, UniTask task11, UniTask task12, UniTask task13)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                StartTask(task1, 0);
+                StartTask(task2, 1);
+                StartTask(task3, 2);
+                StartTask(task4, 3);
+                StartTask(task5, 4);
+                StartTask(task6, 5);
+                StartTask(task7, 6);
+                StartTask(task8, 7);
+                StartTask(task9, 8);
+                StartTask(task10, 9);
+                StartTask(task11, 10);
+                StartTask(task12, 11);
+                StartTask(task13, 12);
+            }
+
+            public WhenAnyPromise(UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5, UniTask task6, UniTask task7, UniTask task8, UniTask task9, UniTask task10, UniTask task11, UniTask task12, UniTask task13, UniTask task14)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                StartTask(task1, 0);
+                StartTask(task2, 1);
+                StartTask(task3, 2);
+                StartTask(task4, 3);
+                StartTask(task5, 4);
+                StartTask(task6, 5);
+                StartTask(task7, 6);
+                StartTask(task8, 7);
+                StartTask(task9, 8);
+                StartTask(task10, 9);
+                StartTask(task11, 10);
+                StartTask(task12, 11);
+                StartTask(task13, 12);
+                StartTask(task14, 13);
+            }
+
+            public WhenAnyPromise(UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5, UniTask task6, UniTask task7, UniTask task8, UniTask task9, UniTask task10, UniTask task11, UniTask task12, UniTask task13, UniTask task14, UniTask task15)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                StartTask(task1, 0);
+                StartTask(task2, 1);
+                StartTask(task3, 2);
+                StartTask(task4, 3);
+                StartTask(task5, 4);
+                StartTask(task6, 5);
+                StartTask(task7, 6);
+                StartTask(task8, 7);
+                StartTask(task9, 8);
+                StartTask(task10, 9);
+                StartTask(task11, 10);
+                StartTask(task12, 11);
+                StartTask(task13, 12);
+                StartTask(task14, 13);
+                StartTask(task15, 14);
+            }
+
+            void StartTask(UniTask task, int index)
+            {
+                Awaiter awaiter;
+
+                try
+                {
+                    awaiter = task.GetAwaiter();
+                }
+                catch (Exception ex)
+                {
+                    core.TrySetException(ex);
+                    return; // consume others.
+                }
+
+                if (awaiter.IsCompleted)
+                {
+                    TryInvokeContinuation(this, awaiter, index);
+                }
+                else
+                {
+                    awaiter.SourceOnCompleted(state =>
+                    {
+                        using (var t = (StateTuple<WhenAnyPromise, Awaiter, int>)state)
+                        {
+                            TryInvokeContinuation(t.Item1, t.Item2, t.Item3);
+                        }
+                    }, StateTuple.Create(this, awaiter, index));
+                }
+            }
+        }
     }
 }

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTask.WhenAny.Generated.tt
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTask.WhenAny.Generated.tt
@@ -113,5 +113,61 @@ namespace Cysharp.Threading.Tasks
         }
 
 <# } #>
+<# for(var i = 2; i <= 15; i++ ) {
+    var range = Enumerable.Range(1, i);
+    var args = string.Join(", ", range.Select(x => $"UniTask task{x}"));
+    var targs = string.Join(", ", range.Select(x => $"task{x}"));
+#>
+        public static UniTask<int> WhenAny(<#= args #>)
+        {
+            return new UniTask<int>(new WhenAnyPromise(<#= targs #>), 0);
+        }
+
+<# } #>
+        sealed partial class WhenAnyPromise : IUniTaskSource<int>
+        {
+<# for(var i = 2; i <= 15; i++ ) {
+    var range = Enumerable.Range(1, i);
+    var args = string.Join(", ", range.Select(x => $"UniTask task{x}"));
+    var startTasks = string.Join("\n", range.Select(x => $"{new string(' ', 16)}StartTask(task{x}, {x-1});"));
+#>
+            public WhenAnyPromise(<#= args #>)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+<#= startTasks #>
+            }
+
+<# } #>
+            void StartTask(UniTask task, int index)
+            {
+                Awaiter awaiter;
+
+                try
+                {
+                    awaiter = task.GetAwaiter();
+                }
+                catch (Exception ex)
+                {
+                    core.TrySetException(ex);
+                    return; // consume others.
+                }
+
+                if (awaiter.IsCompleted)
+                {
+                    TryInvokeContinuation(this, awaiter, index);
+                }
+                else
+                {
+                    awaiter.SourceOnCompleted(state =>
+                    {
+                        using (var t = (StateTuple<WhenAnyPromise, Awaiter, int>)state)
+                        {
+                            TryInvokeContinuation(t.Item1, t.Item2, t.Item3);
+                        }
+                    }, StateTuple.Create(this, awaiter, index));
+                }
+            }
+        }
     }
 }

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTask.WhenAny.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTask.WhenAny.cs
@@ -265,7 +265,7 @@ namespace Cysharp.Threading.Tasks
             }
         }
 
-        sealed class WhenAnyPromise : IUniTaskSource<int>
+        sealed partial class WhenAnyPromise : IUniTaskSource<int>
         {
             int completedCount;
             UniTaskCompletionSourceCore<int> core;

--- a/src/UniTask/Assets/Tests/AsyncTest.cs
+++ b/src/UniTask/Assets/Tests/AsyncTest.cs
@@ -113,6 +113,37 @@ namespace Cysharp.Threading.TasksTests
         });
 
         [UnityTest]
+        public IEnumerator WhenAllVoid() => UniTask.ToCoroutine(async () =>
+        {
+            bool aResult = false;
+            bool bResult = false;
+            bool cResult = false;
+
+            var a = UniTask.Create(async () =>
+            {
+                await UniTask.DelayFrame(1);
+                aResult = true;
+            });
+
+            var b = UniTask.Create(async () =>
+            {
+                await UniTask.DelayFrame(2);
+                bResult = true;
+            });
+
+            var c = UniTask.Create(async () =>
+            {
+                await UniTask.DelayFrame(3);
+                cResult = true;
+            });
+
+            await UniTask.WhenAll(a, b, c);
+            aResult.Should().Be(true);
+            bResult.Should().Be(true);
+            cResult.Should().Be(true);
+        });
+
+        [UnityTest]
         public IEnumerator WhenAny() => UniTask.ToCoroutine(async () =>
         {
             var a = UniTask.FromResult(999);

--- a/src/UniTask/Assets/Tests/AsyncTest.cs
+++ b/src/UniTask/Assets/Tests/AsyncTest.cs
@@ -125,6 +125,19 @@ namespace Cysharp.Threading.TasksTests
         });
 
         [UnityTest]
+        public IEnumerator WhenAnyVoid() => UniTask.ToCoroutine(async () =>
+        {
+            bool result = false;
+            var a = UniTask.Create(async () => { result = true; });
+            var b = UniTask.Yield(PlayerLoopTiming.Update, CancellationToken.None);
+            var c = UniTask.DelayFrame(99);
+
+            int win = await UniTask.WhenAny(a, b, c);
+            win.Should().Be(0);
+            result.Should().Be(true);
+        });
+
+        [UnityTest]
         public IEnumerator BothEnumeratorCheck() => UniTask.ToCoroutine(async () =>
         {
             await ToaruCoroutineEnumerator(); // wait 5 frame:)


### PR DESCRIPTION
Implements issue #262 

- made WhenAnyPromise and WhenAllPromise classes partial
- added constructors with 2-15 arguments to WhenAnyPromise and WhenAllPromise
- added UniTask.WhenAny(UniTask) and UniTask.WhenAll(UniTask) overloads with 2-15 arguments using those constructors
- added unit tests for WhenAny and WhenAll methods with three arguments. Let me know if I should test more overloads.