### PR TITLE
Fix exceptions never being reported when UniTask is executed without await and Forget()

### DIFF
--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTask.Factory.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTask.Factory.cs
@@ -194,6 +194,7 @@ namespace Cysharp.Threading.Tasks
         sealed class ExceptionResultSource : IUniTaskSource
         {
             readonly ExceptionDispatchInfo exception;
+            bool calledGet;
 
             public ExceptionResultSource(Exception exception)
             {
@@ -202,6 +203,11 @@ namespace Cysharp.Threading.Tasks
 
             public void GetResult(short token)
             {
+                if (!calledGet)
+                {
+                    calledGet = true;
+                    GC.SuppressFinalize(this);
+                }
                 exception.Throw();
             }
 
@@ -219,11 +225,20 @@ namespace Cysharp.Threading.Tasks
             {
                 continuation(state);
             }
+
+            ~ExceptionResultSource()
+            {
+                if (!calledGet)
+                {
+                    UniTaskScheduler.PublishUnobservedTaskException(exception.SourceException);
+                }
+            }
         }
 
         sealed class ExceptionResultSource<T> : IUniTaskSource<T>
         {
             readonly ExceptionDispatchInfo exception;
+            bool calledGet;
 
             public ExceptionResultSource(Exception exception)
             {
@@ -232,12 +247,22 @@ namespace Cysharp.Threading.Tasks
 
             public T GetResult(short token)
             {
+                if (!calledGet)
+                {
+                    calledGet = true;
+                    GC.SuppressFinalize(this);
+                }
                 exception.Throw();
                 return default;
             }
 
             void IUniTaskSource.GetResult(short token)
             {
+                if (!calledGet)
+                {
+                    calledGet = true;
+                    GC.SuppressFinalize(this);
+                }
                 exception.Throw();
             }
 
@@ -254,6 +279,14 @@ namespace Cysharp.Threading.Tasks
             public void OnCompleted(Action<object> continuation, object state, short token)
             {
                 continuation(state);
+            }
+
+            ~ExceptionResultSource()
+            {
+                if (!calledGet)
+                {
+                    UniTaskScheduler.PublishUnobservedTaskException(exception.SourceException);
+                }
             }
         }
 

--- a/src/UniTask/Assets/Tests/AsyncTest.cs
+++ b/src/UniTask/Assets/Tests/AsyncTest.cs
@@ -366,6 +366,28 @@ namespace Cysharp.Threading.TasksTests
             UniTaskScheduler.UnobservedTaskException -= action;
         });
 
+        [UnityTest]
+        public IEnumerator ThrowExceptionUnawaited() => UniTask.ToCoroutine(async () =>
+        {
+            LogAssert.Expect(LogType.Exception, "Exception: MyException");
+
+#pragma warning disable 1998
+            async UniTask Throw() => throw new Exception("MyException");
+#pragma warning restore 1998
+
+#pragma warning disable 4014
+            Throw();
+#pragma warning restore 4014
+
+            await UniTask.DelayFrame(3);
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+
+            await UniTask.DelayFrame(1);
+        });
+
         async UniTask InException1()
         {
             await UniTask.Yield();


### PR DESCRIPTION
Fixes issue #315 

I tried following your advice to replace `Exception ex` with `ExceptionHolder`. However, it does not resolve the issue because the following happens:
1. `ExceptionHolder` is created and assigned to the field.
2. Task getter is executed and `UniTask.FromException(ex.GetException().SourceException)` is returned.
3. `GetException()` suppresses the `ExceptionHolder`'s finalizer.
4. The returned task is not awaited, and thus the exception is not reported again.

Instead, I found that the issue lays in another part of the code.
`AsyncUniTaskMethodBuilder.Task` getter is executed even if the task is not assigned to a variable:
```
private void Awake()
{
    TestAsync();
}

private async UniTask TestAsync()
{
    throw new Exception();
}
```

Thus, we can't know if the task returned by the Task getter is going to be awaited or not. We need a backup for a case when the task is not going to be awaited.

In the end, I added a finalizer to `ExceptionResultSource`:
```
~ExceptionResultSource()
{
    if (!calledGet)
    {
        UniTaskScheduler.PublishUnobservedTaskException(exception.SourceException);
    }
}
```

It acts the same as `ExceptionHolder`. If the exception is thrown, the finalizer will be suppressed. But if the task is never awaited, the finalizer will publish the exception.