### PR TITLE
ENABLE_PROFILER rather than UNITY_EDITOR controls TaskTracker availability

### DIFF
--- a/src/UniTask/Assets/Plugins/UniTask/Editor/UniTaskTrackerWindow.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Editor/UniTaskTrackerWindow.cs
@@ -39,9 +39,9 @@ namespace Cysharp.Threading.Tasks.Editor
             window = this; // set singleton.
             splitterState = SplitterGUILayout.CreateSplitterState(new float[] { 75f, 25f }, new int[] { 32, 32 }, null);
             treeView = new UniTaskTrackerTreeView();
-            TaskTracker.EditorEnableState.EnableAutoReload = EditorPrefs.GetBool(TaskTracker.EnableAutoReloadKey, false);
-            TaskTracker.EditorEnableState.EnableTracking = EditorPrefs.GetBool(TaskTracker.EnableTrackingKey, false);
-            TaskTracker.EditorEnableState.EnableStackTrace = EditorPrefs.GetBool(TaskTracker.EnableStackTraceKey, false);
+            TaskTracker.EnableState.EnableAutoReload = EditorPrefs.GetBool(TaskTracker.EnableAutoReloadKey, false);
+            TaskTracker.EnableState.EnableTracking = EditorPrefs.GetBool(TaskTracker.EnableTrackingKey, false);
+            TaskTracker.EnableState.EnableStackTrace = EditorPrefs.GetBool(TaskTracker.EnableStackTraceKey, false);
         }
 
         void OnGUI()
@@ -63,9 +63,9 @@ namespace Cysharp.Threading.Tasks.Editor
 
         #region HeadPanel
 
-        public static bool EnableAutoReload => TaskTracker.EditorEnableState.EnableAutoReload;
-        public static bool EnableTracking => TaskTracker.EditorEnableState.EnableTracking;
-        public static bool EnableStackTrace => TaskTracker.EditorEnableState.EnableStackTrace;
+        public static bool EnableAutoReload => TaskTracker.EnableState.EnableAutoReload;
+        public static bool EnableTracking => TaskTracker.EnableState.EnableTracking;
+        public static bool EnableStackTrace => TaskTracker.EnableState.EnableStackTrace;
         static readonly GUIContent EnableAutoReloadHeadContent = EditorGUIUtility.TrTextContent("Enable AutoReload", "Reload automatically.", (Texture)null);
         static readonly GUIContent ReloadHeadContent = EditorGUIUtility.TrTextContent("Reload", "Reload View.", (Texture)null);
         static readonly GUIContent GCHeadContent = EditorGUIUtility.TrTextContent("GC.Collect", "Invoke GC.Collect.", (Texture)null);
@@ -80,17 +80,17 @@ namespace Cysharp.Threading.Tasks.Editor
 
             if (GUILayout.Toggle(EnableAutoReload, EnableAutoReloadHeadContent, EditorStyles.toolbarButton, EmptyLayoutOption) != EnableAutoReload)
             {
-                TaskTracker.EditorEnableState.EnableAutoReload = !EnableAutoReload;
+                TaskTracker.EnableState.EnableAutoReload = !EnableAutoReload;
             }
 
             if (GUILayout.Toggle(EnableTracking, EnableTrackingHeadContent, EditorStyles.toolbarButton, EmptyLayoutOption) != EnableTracking)
             {
-                TaskTracker.EditorEnableState.EnableTracking = !EnableTracking;
+                TaskTracker.EnableState.EnableTracking = !EnableTracking;
             }
 
             if (GUILayout.Toggle(EnableStackTrace, EnableStackTraceHeadContent, EditorStyles.toolbarButton, EmptyLayoutOption) != EnableStackTrace)
             {
-                TaskTracker.EditorEnableState.EnableStackTrace = !EnableStackTrace;
+                TaskTracker.EnableState.EnableStackTrace = !EnableStackTrace;
             }
 
             GUILayout.FlexibleSpace();

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/Internal/TaskTracker.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/Internal/TaskTracker.cs
@@ -76,7 +76,7 @@ namespace Cysharp.Threading.Tasks
         [Conditional( "ENABLE_PROFILER" )]
         public static void TrackActiveTask(IUniTaskSource task, int skipFrame)
         {
-#if UNITY_EDITOR
+#if ENABLE_PROFILER
             dirty = true;
             if (!EnableState.EnableTracking) return;
             var stackTrace = EnableState.EnableStackTrace ? new StackTrace(skipFrame, true).CleanupAsyncStackTrace() : "";
@@ -99,7 +99,7 @@ namespace Cysharp.Threading.Tasks
         [Conditional( "ENABLE_PROFILER" )]
         public static void RemoveTracking(IUniTaskSource task)
         {
-#if UNITY_EDITOR
+#if ENABLE_PROFILER
             dirty = true;
             if (!EnableState.EnableTracking) return;
             var success = tracking.TryRemove(task);

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/Internal/TaskTracker.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/Internal/TaskTracker.cs
@@ -21,7 +21,7 @@ namespace Cysharp.Threading.Tasks
         public const string EnableTrackingKey = "UniTaskTrackerWindow_EnableTrackingKey";
         public const string EnableStackTraceKey = "UniTaskTrackerWindow_EnableStackTraceKey";
 
-        public static class EditorEnableState
+        public static class EnableState
         {
             static bool enableAutoReload;
             public static bool EnableAutoReload
@@ -57,6 +57,15 @@ namespace Cysharp.Threading.Tasks
             }
         }
 
+#elif ENABLE_PROFILER
+
+        public static class EnableState
+        {
+            public static bool EnableAutoReload;
+            public static bool EnableTracking;
+            public static bool EnableStackTrace;
+        }
+
 #endif
 
 
@@ -64,16 +73,16 @@ namespace Cysharp.Threading.Tasks
 
         static readonly WeakDictionary<IUniTaskSource, (string formattedType, int trackingId, DateTime addTime, string stackTrace)> tracking = new WeakDictionary<IUniTaskSource, (string formattedType, int trackingId, DateTime addTime, string stackTrace)>();
 
-        [Conditional("UNITY_EDITOR")]
+        [Conditional( "ENABLE_PROFILER" )]
         public static void TrackActiveTask(IUniTaskSource task, int skipFrame)
         {
 #if UNITY_EDITOR
             dirty = true;
-            if (!EditorEnableState.EnableTracking) return;
-            var stackTrace = EditorEnableState.EnableStackTrace ? new StackTrace(skipFrame, true).CleanupAsyncStackTrace() : "";
+            if (!EnableState.EnableTracking) return;
+            var stackTrace = EnableState.EnableStackTrace ? new StackTrace(skipFrame, true).CleanupAsyncStackTrace() : "";
 
             string typeName;
-            if (EditorEnableState.EnableStackTrace)
+            if (EnableState.EnableStackTrace)
             {
                 var sb = new StringBuilder();
                 TypeBeautify(task.GetType(), sb);
@@ -87,12 +96,12 @@ namespace Cysharp.Threading.Tasks
 #endif
         }
 
-        [Conditional("UNITY_EDITOR")]
+        [Conditional( "ENABLE_PROFILER" )]
         public static void RemoveTracking(IUniTaskSource task)
         {
 #if UNITY_EDITOR
             dirty = true;
-            if (!EditorEnableState.EnableTracking) return;
+            if (!EnableState.EnableTracking) return;
             var success = tracking.TryRemove(task);
 #endif
         }


### PR DESCRIPTION
The task tracker window is incredibly useful in editor but, since the majority of profiling tends to happen on the device, being able to track tasks that are running in a proper build is incredibly useful.

I have my own profiler counters API for tracking where tasks are coming from based on the information contained in the tracker. I do think a feature like this in the future would be useful, but in the meantime it would be handy to at least have it as an available option without requiring a forked UniTask.