### PR TITLE
Diagnostics helper null check

### DIFF
--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/PlayerLoopHelper.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/PlayerLoopHelper.cs
@@ -524,11 +524,19 @@ namespace Cysharp.Threading.Tasks
             {
                 sb.AppendFormat("------{0}------", header.type.Name);
                 sb.AppendLine();
+                
+                if (header.subSystemList is null) 
+                {
+                    sb.AppendFormat("{0} has no subsystems!", header.ToString());
+                    sb.AppendLine();
+                    continue;
+                }
+                
                 foreach (var subSystem in header.subSystemList)
                 {
                     sb.AppendFormat("{0}", subSystem.type.Name);
                     sb.AppendLine();
-
+                    
                     if (subSystem.subSystemList != null)
                     {
                         UnityEngine.Debug.LogWarning("More Subsystem:" + subSystem.subSystemList.Length);
@@ -545,6 +553,11 @@ namespace Cysharp.Threading.Tasks
 
             foreach (var header in playerLoop.subSystemList)
             {
+                if (header.subSystemList is null) 
+                { 
+                    continue;
+                }
+                
                 foreach (var subSystem in header.subSystemList)
                 {
                     if (subSystem.type == typeof(UniTaskLoopRunners.UniTaskLoopRunnerInitialization))

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/PlayerLoopHelper.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/PlayerLoopHelper.cs
@@ -531,7 +531,7 @@ namespace Cysharp.Threading.Tasks
                     sb.AppendLine();
                     continue;
                 }
-                
+
                 foreach (var subSystem in header.subSystemList)
                 {
                     sb.AppendFormat("{0}", subSystem.type.Name);

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/PlayerLoopHelper.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/PlayerLoopHelper.cs
@@ -536,7 +536,7 @@ namespace Cysharp.Threading.Tasks
                 {
                     sb.AppendFormat("{0}", subSystem.type.Name);
                     sb.AppendLine();
-                    
+
                     if (subSystem.subSystemList != null)
                     {
                         UnityEngine.Debug.LogWarning("More Subsystem:" + subSystem.subSystemList.Length);


### PR DESCRIPTION
[In the PlayerLoop section of the ReadMe](https://github.com/Cysharp/UniTask#playerloop) the following code snipped is recommended to check if UniTask is running correctly: 

> You can diagnose whether UniTask's player loop is ready by calling PlayerLoopHelper.IsInjectedUniTaskPlayerLoop(). 
And also PlayerLoopHelper.DumpCurrentPlayerLoop logs all current playerloops to console.*

```

void Start()
{
    UnityEngine.Debug.Log("UniTaskPlayerLoop ready? " + PlayerLoopHelper.IsInjectedUniTaskPlayerLoop());
    PlayerLoopHelper.DumpCurrentPlayerLoop();
}
```

----


Using this code snipped I would always be presented with a NRE due to a missing subSystem list. I've added some null checks to avoid that. There is also a log now which informs you when there are no subsystems present.

Error message:
```
NullReferenceException: Object reference not set to an instance of an object
Cysharp.Threading.Tasks.PlayerLoopHelper.IsInjectedUniTaskPlayerLoop () (at Library/PackageCache/com.cysharp.unitask@9e2163616b/Runtime/PlayerLoopHelper.cs:768)
RocketRaptor.Synergy.Scope.BuilderExtension.SetupUniTask () (at Assets/_Scripts/BuilderExtension.cs:90)
RocketRaptor.Synergy.Scope.ArenaScope.Configure (VContainer.IContainerBuilder builder) (at Assets/_Scripts/ArenaScope.cs:53)
VContainer.Unity.LifetimeScope.InstallTo (VContainer.IContainerBuilder builder) (at Library/PackageCache/jp.hadashikick.vcontainer@80086eec36/Runtime/Unity/LifetimeScope.cs:229)
VContainer.Unity.LifetimeScope.Build () (at Library/PackageCache/jp.hadashikick.vcontainer@80086eec36/Runtime/Unity/LifetimeScope.cs:175)
VContainer.Unity.LifetimeScope.Awake () (at Library/PackageCache/jp.hadashikick.vcontainer@80086eec36/Runtime/Unity/LifetimeScope.cs:121)
```


With the changes I get the following output (I have Entities installed):

```
PlayerLoop List
------UpdatePreFrame------
UpdatePreFrame has no subsystems!
------TimeUpdate------
UniTaskLoopRunnerYieldTimeUpdate
UniTaskLoopRunnerTimeUpdate
WaitForLastPresentationAndUpdateTime

[...]

UniTaskLoopRunnerLastPostLateUpdate
------UpdatePostFrame------
UpdatePostFrame has no subsystems!
```

Full logs [here](https://gist.github.com/kroonhorstdino/2b363e0ffa95279c0e2a55a3c45e7be8)
