### PR TITLE
fix: prevent NullReferenceException in TimeoutController

### DIFF
--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/TimeoutController.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/TimeoutController.cs
@@ -109,7 +109,7 @@ namespace Cysharp.Threading.Tasks
             try
             {
                 // stop timer.
-                timer.Dispose();
+                timer?.Dispose();
 
                 // cancel and dispose.
                 timeoutSource.Cancel();

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/TimeoutController.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/TimeoutController.cs
@@ -99,7 +99,7 @@ namespace Cysharp.Threading.Tasks
 
         public void Reset()
         {
-            timer.Stop();
+            timer?.Stop();
         }
 
         public void Dispose()


### PR DESCRIPTION
Prevents NullReferenceException thrown when Dispose is called without calling Timeout in TimeoutController.

code to reproduce
```cs
void Start()
{
    var tc = new TimeoutController();
    tc.Dispose();
}
```