### PR TITLE
Fix cancellation token forwarding

### DIFF
--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTaskObservableExtensions.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTaskObservableExtensions.cs
@@ -133,7 +133,7 @@ namespace Cysharp.Threading.Tasks
             {
                 var self = (ToUniTaskObserver<T>)state;
                 self.disposable.Dispose();
-                self.promise.TrySetCanceled();
+                self.promise.TrySetCanceled(self.cancellationToken);
             }
 
             public void OnNext(T value)
@@ -203,7 +203,7 @@ namespace Cysharp.Threading.Tasks
             {
                 var self = (FirstValueToUniTaskObserver<T>)state;
                 self.disposable.Dispose();
-                self.promise.TrySetCanceled();
+                self.promise.TrySetCanceled(self.cancellationToken);
             }
 
             public void OnNext(T value)


### PR DESCRIPTION
Fix cancellation token forwarding at FirstValueToUniTaskObserver and ToUniTaskObserver; Issue [https://github.com/Cysharp/UniTask/issues/406](url)