### PR TITLE
Unwrap single inner exception in AggregateException

### DIFF
--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTaskCompletionSource.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTaskCompletionSource.cs
@@ -46,12 +46,13 @@ namespace Cysharp.Threading.Tasks
 
         public ExceptionHolder(Exception exception)
         {
-            if (exception is AggregateException aex && aex.InnerExceptions?.Count == 1)
+            var flattenedAggregate = (exception as AggregateException)?.Flatten();
+            if (flattenedAggregate?.InnerExceptions?.Count == 1)
             {
-                this.exception = ExceptionDispatchInfo.Capture(aex.InnerExceptions[0]);
+                this.exception = ExceptionDispatchInfo.Capture(flattenedAggregate.InnerExceptions[0]);
             }
             else
-        {
+            {
                 this.exception = ExceptionDispatchInfo.Capture(exception);
             }
         }

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTaskCompletionSource.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTaskCompletionSource.cs
@@ -44,9 +44,16 @@ namespace Cysharp.Threading.Tasks
         ExceptionDispatchInfo exception;
         bool calledGet = false;
 
-        public ExceptionHolder(ExceptionDispatchInfo exception)
+        public ExceptionHolder(Exception exception)
         {
-            this.exception = exception;
+            if (exception is AggregateException aex && aex.InnerExceptions?.Count == 1)
+            {
+                this.exception = ExceptionDispatchInfo.Capture(aex.InnerExceptions[0]);
+            }
+            else
+        {
+                this.exception = ExceptionDispatchInfo.Capture(exception);
+            }
         }
 
         public ExceptionDispatchInfo GetException()

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTaskCompletionSource.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTaskCompletionSource.cs
@@ -166,7 +166,7 @@ namespace Cysharp.Threading.Tasks
                 }
                 else
                 {
-                    this.error = new ExceptionHolder(ExceptionDispatchInfo.Capture(error));
+                    this.error = new ExceptionHolder(error);
                 }
 
                 if (continuation != null || Interlocked.CompareExchange(ref this.continuation, UniTaskCompletionSourceCoreShared.s_sentinel, null) != null)
@@ -635,7 +635,7 @@ namespace Cysharp.Threading.Tasks
 
             if (UnsafeGetStatus() != UniTaskStatus.Pending) return false;
 
-            this.exception = new ExceptionHolder(ExceptionDispatchInfo.Capture(exception));
+            this.exception = new ExceptionHolder(exception);
             return TrySignalCompletion(UniTaskStatus.Faulted);
         }
 
@@ -820,7 +820,7 @@ namespace Cysharp.Threading.Tasks
 
             if (UnsafeGetStatus() != UniTaskStatus.Pending) return false;
 
-            this.exception = new ExceptionHolder(ExceptionDispatchInfo.Capture(exception));
+            this.exception = new ExceptionHolder(exception);
             return TrySignalCompletion(UniTaskStatus.Faulted);
         }
 


### PR DESCRIPTION
This way a `AggregateException` wrapping vanishes if it just acts as an inconvenient structure around a single inner exception.

Note: I moved the `Capture()` calls to the ctor of `ExceptionHolder` so instead of multiple checks scattered about there is just this single one. Because of this I had to change the ctor's parameter from `ExceptionDispatchInfo` to `Exception`. I do not know if passing the exception down has maybe side effects but I guess it would not matter in this case.