### PR TITLE
DoTween null reference on destroy fix

### DIFF
--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/External/DOTween/DOTweenAsyncExtensions.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/External/DOTween/DOTweenAsyncExtensions.cs
@@ -101,7 +101,7 @@ namespace Cysharp.Threading.Tasks
         
         public static async UniTask AwaitWithCancellation(this Tween tween, CancellationToken cancellationToken)
         {
-            Error.ThrowArgumentNullException(tween, nameof(tween));
+			Error.ThrowArgumentNullException(tween, nameof(tween));
 
 			if (!tween.IsActive()) await UniTask.CompletedTask;
             

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/External/DOTween/DOTweenAsyncExtensions.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/External/DOTween/DOTweenAsyncExtensions.cs
@@ -105,17 +105,15 @@ namespace Cysharp.Threading.Tasks
 
             if (!tween.IsActive()) return UniTask.CompletedTask;
             
-            var registration = cancellationToken.Register(() =>
-            {
-                if (tween.IsActive())
-                {
-                    tween.Kill();
-                }
-            });
+            using var registration = cancellationToken.Register(() =>
+			{
+				if (tween.IsActive())
+				{
+					tween.Kill();
+				}
+			});
 
-            tween.OnKill((() => registration.Dispose()));
-
-            return tween.ToUniTask(TweenCancelBehaviour.KillAndCancelAwait, cancellationToken);
+			return tween.ToUniTask(TweenCancelBehaviour.KillAndCancelAwait, cancellationToken);
         }
 
         public struct TweenAwaiter : ICriticalNotifyCompletion

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/External/DOTween/DOTweenAsyncExtensions.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/External/DOTween/DOTweenAsyncExtensions.cs
@@ -99,13 +99,13 @@ namespace Cysharp.Threading.Tasks
             return new UniTask(TweenConfiguredSource.Create(tween, tweenCancelBehaviour, cancellationToken, CallbackType.StepComplete, out var token), token);
         }
         
-        public static UniTask AwaitWithCancellation(this Tween tween, CancellationToken cancellationToken)
+        public static async UniTask AwaitWithCancellation(this Tween tween, CancellationToken cancellationToken)
         {
             Error.ThrowArgumentNullException(tween, nameof(tween));
 
-            if (!tween.IsActive()) return UniTask.CompletedTask;
+			if (!tween.IsActive()) await UniTask.CompletedTask;
             
-            using var registration = cancellationToken.Register(() =>
+			using var registration = cancellationToken.Register(() =>
 			{
 				if (tween.IsActive())
 				{
@@ -113,7 +113,7 @@ namespace Cysharp.Threading.Tasks
 				}
 			});
 
-			return tween.ToUniTask(TweenCancelBehaviour.KillAndCancelAwait, cancellationToken);
+			await tween.ToUniTask(TweenCancelBehaviour.KillAndCancelAwait, cancellationToken);
         }
 
         public struct TweenAwaiter : ICriticalNotifyCompletion


### PR DESCRIPTION
Greetings!
There is an issue, that throws DoTween null reference if destroying tweened GameObject, while the tween is still playing if using extension method GetCancellationTokenOnDestroy() and pass the given token to the AwaitForComplete()/ToUniTask()/WithCancellation() methods.

Here is an extension method that solves this problem and I want to merge it into the main branch.


```
var token = this.GetCancellationTokenOnDestroy();

transform.DOScale(Vector3.one, 2f).WithCancellation(token); //throws null reference on destroy
			
transform.DOScale(Vector3.one, 2f).AwaitForComplete(cancellationToken: token); //throws null reference on destroy
			
transform.DOScale(Vector3.one, 2f).ToUniTask(cancellationToken: token); //throws null reference on destroy
			
transform.DOScale(Vector3.one, 2f).AwaitWithCancellation(token); //Do not throw null reference on destroy
```
