### PR TITLE
Fixed https://github.com/Cysharp/UniTask/issues/444

### DIFF
--- a/src/UniTask/Assets/Tests/AsyncReactivePropertyTest.cs
+++ b/src/UniTask/Assets/Tests/AsyncReactivePropertyTest.cs
@@ -1,0 +1,63 @@
+﻿using Cysharp.Threading.Tasks;
+using FluentAssertions;
+using System;
+using System.Collections;
+using System.Threading;
+using UnityEngine.TestTools;
+
+namespace Cysharp.Threading.TasksTests
+{
+    public class AsyncReactivePropertyTest
+    {
+        private int _callCounter;
+        
+        [UnityTest]
+        public IEnumerator WaitCancelWait() => UniTask.ToCoroutine(async () =>
+        {
+            // Test case for https://github.com/Cysharp/UniTask/issues/444
+            
+            var property = new AsyncReactiveProperty<int>(0);
+            
+            var cts1 = new CancellationTokenSource();
+            var cts2 = new CancellationTokenSource();
+            WaitForProperty(property, cts1.Token);
+            WaitForProperty(property, cts2.Token);
+
+            _callCounter = 0;
+            property.Value = 1;
+            _callCounter.Should().Be(2);
+
+            cts2.Cancel();
+            cts2.Dispose();
+            cts1.Cancel();
+            cts1.Dispose();
+
+            var cts3 = new CancellationTokenSource();
+            WaitForProperty(property, cts3.Token);
+
+            _callCounter = 0;
+            property.Value = 2;
+            _callCounter.Should().Be(1);
+            
+            cts3.Cancel();
+            cts3.Dispose();
+            await UniTask.CompletedTask;
+        });
+
+        private async void WaitForProperty(AsyncReactiveProperty<int> property, CancellationToken token)
+        {
+            while (true)
+            {
+                try
+                {
+                    await property.WaitAsync(token);
+                    _callCounter++;
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/src/UniTask/Assets/Tests/AsyncReactivePropertyTest.cs.meta
+++ b/src/UniTask/Assets/Tests/AsyncReactivePropertyTest.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 27665955eefb4448969b8cc4dd204600
+timeCreated: 1676129650


### PR DESCRIPTION
This PR fixes https://github.com/Cysharp/UniTask/issues/444 and adds a unit test for this case.

The cause of this issue is in AsyncReactiveProperty.TryReturn(): here we remove WaitAsyncSource from triggers and push it to pool, but Remove() may do nothing if we are iterating right now. This actually happens in the case https://github.com/Cysharp/UniTask/issues/444:
1. We push not removed WaitAsyncSource to pool
2. We want to create new WaitAsyncSource, so we take that not removed item from the pool
3. After iteration is ended we are calling Remove() for that reused item thus leading to next/prev pointers corruption.
Next steps in the unit test are needed to reveal this problem.

To fix this we can possibly not pushing WaitAsyncSource to the pool if it is not removed. But this would lead to allocations. Instead of this I just removed a mechanism of trigger removal delaying (preserveRemoveSelf boolean). I don't know for what case this mechanism was introduced, but as for now everything works just fine without it.
