### PR TITLE
Added AsUniTask methods with CancellationToken support

### DIFF
--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTaskExtensions.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTaskExtensions.cs
@@ -41,7 +41,7 @@ namespace Cysharp.Threading.Tasks
             return promise.Task;
         }
 
-        public static UniTask<T> AsUniTask<T>(this Task<T> task, CancellationToken cancellationToken = default, bool useCurrentSynchronizationContext = true)
+        public static UniTask<T> AsUniTask<T>(this Task<T> task, CancellationToken cancellationToken, bool useCurrentSynchronizationContext = true)
         {
             var promise = new UniTaskCompletionSource<T>();
             var state = StatePool<UniTaskCompletionSource<T>, CancellationToken>.Create(promise, cancellationToken);
@@ -102,7 +102,7 @@ namespace Cysharp.Threading.Tasks
             return promise.Task;
         }
 
-        public static UniTask AsUniTask(this Task task, CancellationToken cancellationToken = default, bool useCurrentSynchronizationContext = true)
+        public static UniTask AsUniTask(this Task task, CancellationToken cancellationToken, bool useCurrentSynchronizationContext = true)
         {
             var promise = new UniTaskCompletionSource();
             var state = StatePool<UniTaskCompletionSource, CancellationToken>.Create(promise, cancellationToken);


### PR DESCRIPTION
Sometimes it is necessary to use logic that depends on CancellationToken passed with OperationCancelledException (eg. https://neuecc.medium.com/patterns-practices-for-efficiently-handling-c-async-await-cancel-processing-and-timeouts-b419ce5f69a4)
But, since there is no official way to get the CancellationToken from a Task object, method AsUniTask just passed default CancellationToken in case of cancellation. I have implemented additional methods AsUniTask, that support it.