### PR TITLE
Fix problem with finally in UniTaskAsyncEnumerable.Create not being executed

### DIFF
--- a/src/UniTask.NetCoreTests/Linq/CreateTest.cs
+++ b/src/UniTask.NetCoreTests/Linq/CreateTest.cs
@@ -159,6 +159,30 @@ namespace NetCoreTests.Linq
             list.Should().Equal(100, 200, 300, 400);
         }
 
+        [Fact]
+        public async Task AwaitForeachBreak()
+        {
+            var finallyCalled = false;
+            var enumerable = UniTaskAsyncEnumerable.Create<int>(async (writer, _) =>
+            {
+                try
+                {
+                    await writer.YieldAsync(1);
+                }
+                finally
+                {
+                    finallyCalled = true;
+                }
+            });
+
+            await foreach (var x in enumerable)
+            {
+                x.Should().Be(1);
+                break;
+            }
+            finallyCalled.Should().BeTrue();
+        }
+
         async IAsyncEnumerable<int> Range(int from, int count)
         {
             for (int i = 0; i < count; i++)

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/Linq/Create.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/Linq/Create.cs
@@ -52,6 +52,7 @@ namespace Cysharp.Threading.Tasks.Linq
             public UniTask DisposeAsync()
             {
                 TaskTracker.RemoveTracking(this);
+                writer.Dispose();
                 return default;
             }
 
@@ -127,7 +128,7 @@ namespace Cysharp.Threading.Tasks.Linq
             }
         }
 
-        sealed class AsyncWriter : IUniTaskSource, IAsyncWriter<T>
+        sealed class AsyncWriter : IUniTaskSource, IAsyncWriter<T>, IDisposable
         {
             readonly _Create enumerator;
 
@@ -137,6 +138,15 @@ namespace Cysharp.Threading.Tasks.Linq
             {
                 this.enumerator = enumerator;
             }
+            
+            public void Dispose()
+            {
+                var status = core.GetStatus(core.Version);
+                if (status == UniTaskStatus.Pending)
+                {
+                    core.TrySetCanceled();
+                }
+            }            
 
             public void GetResult(short token)
             {


### PR DESCRIPTION
#438 

If await foreach break in the middle, the factory declared in UniTaskAsyncEnumerable.Create(...) is not executed until the end.


```csharp
await foreach (var elem in IterateAsync())
{
    Console.WriteLine("elem: " + elem);
    break;
}
```

```csharp
static IUniTaskAsyncEnumerable<int> IterateAsync()
{
    return UniTaskAsyncEnumerable.Create<int>(async (writer, _) =>
    {
        try
        {
            await writer.YieldAsync(0);
        }
        finally
        {
            Console.WriteLine("Finally block"); // Never executes.
        }
    });
}
```

Perhaps the cause is that YieldAsync() is not completing;  Calling YieldAsync() immediately breaks the await foreach, so the AsyncEnumerable is disposed; the YieldAsync awaiter state machine never calls the last MoveNext.

I added a AsyncWriter.Dispose so that it will complete if YieldAsync is in a pending state.