### PR TITLE
Use innerException for `Task.AsUniTask`

### DIFF
--- a/src/UniTask.NetCoreTests/TaskExtensionsTest.cs
+++ b/src/UniTask.NetCoreTests/TaskExtensionsTest.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Threading.Tasks;
+using Cysharp.Threading.Tasks;
+using Xunit;
+
+namespace NetCoreTests
+{
+    public class TaskExtensionsTest
+    {
+        [Fact]
+        public async Task PropagateException()
+        {
+            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await ThrowAsync().AsUniTask();
+            });
+            
+            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await ThrowOrValueAsync().AsUniTask();
+            });
+            
+
+            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await Task.WhenAll(ThrowAsync(), ThrowAsync(), ThrowAsync());
+            });
+        }
+        
+        async Task ThrowAsync()
+        {
+            throw new InvalidOperationException();
+        }
+
+        async Task<int> ThrowOrValueAsync()
+        {
+            throw new InvalidOperationException();
+        }
+   }
+}

--- a/src/UniTask.NetCoreTests/TaskExtensionsTest.cs
+++ b/src/UniTask.NetCoreTests/TaskExtensionsTest.cs
@@ -20,15 +20,6 @@ namespace NetCoreTests
                 await ThrowOrValueAsync().AsUniTask();
             });
         }
-
-        [Fact]
-        public async Task PropagateWhenAllException()
-        {
-            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
-            {
-                await Task.WhenAll(ThrowAsync(), ThrowAsync(), ThrowAsync()).AsUniTask();
-            });
-        }
  
         async Task ThrowAsync()
         {

--- a/src/UniTask.NetCoreTests/TaskExtensionsTest.cs
+++ b/src/UniTask.NetCoreTests/TaskExtensionsTest.cs
@@ -19,14 +19,17 @@ namespace NetCoreTests
             {
                 await ThrowOrValueAsync().AsUniTask();
             });
-            
+        }
 
+        [Fact]
+        public async Task PropagateWhenAllException()
+        {
             await Assert.ThrowsAsync<InvalidOperationException>(async () =>
             {
-                await Task.WhenAll(ThrowAsync(), ThrowAsync(), ThrowAsync());
+                await Task.WhenAll(ThrowAsync(), ThrowAsync(), ThrowAsync()).AsUniTask();
             });
         }
-        
+ 
         async Task ThrowAsync()
         {
             throw new InvalidOperationException();

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTaskExtensions.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTaskExtensions.cs
@@ -28,7 +28,7 @@ namespace Cysharp.Threading.Tasks
                         p.TrySetCanceled();
                         break;
                     case TaskStatus.Faulted:
-                        p.TrySetException(x.Exception);
+                        p.TrySetException(x.Exception.InnerExceptions.Count == 1 ? x.Exception.InnerException : x.Exception);
                         break;
                     case TaskStatus.RanToCompletion:
                         p.TrySetResult(x.Result);
@@ -58,7 +58,7 @@ namespace Cysharp.Threading.Tasks
                         p.TrySetCanceled();
                         break;
                     case TaskStatus.Faulted:
-                        p.TrySetException(x.Exception);
+                        p.TrySetException(x.Exception.InnerExceptions.Count == 1 ? x.Exception.InnerException : x.Exception);
                         break;
                     case TaskStatus.RanToCompletion:
                         p.TrySetResult();

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTaskExtensions.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTaskExtensions.cs
@@ -28,7 +28,7 @@ namespace Cysharp.Threading.Tasks
                         p.TrySetCanceled();
                         break;
                     case TaskStatus.Faulted:
-                        p.TrySetException(x.Exception.InnerException);
+                        p.TrySetException(x.Exception.InnerExceptions.Count == 1 ? x.Exception.InnerException : x.Exception);
                         break;
                     case TaskStatus.RanToCompletion:
                         p.TrySetResult(x.Result);
@@ -58,7 +58,7 @@ namespace Cysharp.Threading.Tasks
                         p.TrySetCanceled();
                         break;
                     case TaskStatus.Faulted:
-                        p.TrySetException(x.Exception.InnerException);
+                        p.TrySetException(x.Exception.InnerExceptions.Count == 1 ? x.Exception.InnerException : x.Exception);
                         break;
                     case TaskStatus.RanToCompletion:
                         p.TrySetResult();

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTaskExtensions.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTaskExtensions.cs
@@ -28,7 +28,7 @@ namespace Cysharp.Threading.Tasks
                         p.TrySetCanceled();
                         break;
                     case TaskStatus.Faulted:
-                        p.TrySetException(x.Exception.InnerExceptions.Count == 1 ? x.Exception.InnerException : x.Exception);
+                        p.TrySetException(x.Exception.InnerException);
                         break;
                     case TaskStatus.RanToCompletion:
                         p.TrySetResult(x.Result);
@@ -58,7 +58,7 @@ namespace Cysharp.Threading.Tasks
                         p.TrySetCanceled();
                         break;
                     case TaskStatus.Faulted:
-                        p.TrySetException(x.Exception.InnerExceptions.Count == 1 ? x.Exception.InnerException : x.Exception);
+                        p.TrySetException(x.Exception.InnerException);
                         break;
                     case TaskStatus.RanToCompletion:
                         p.TrySetResult();


### PR DESCRIPTION
#422 #428

The problem is that if Task.AsUniTask throws an exception, it becomes an AggregateException.

It seems that there is a historical reason why Task holds AggregateException internally.
We have fixed it as such, as supplementing InnerException is probably sufficient in most cases.

