### PR TITLE
Earlier intialization for Unitask, depending on unity version

### DIFF
--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/PlayerLoopHelper.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/PlayerLoopHelper.cs
@@ -285,7 +285,11 @@ namespace Cysharp.Threading.Tasks
             return dest.ToArray();
         }
 
-        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+#if UNITY_2020_1_OR_NEWER
+		[RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterAssembliesLoaded)]
+#else
+		[RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+#endif
         static void Init()
         {
             // capture default(unity) sync-context.


### PR DESCRIPTION
Current Issue:
UniTask is currently initialized during BeforeSceneLoad.
Execution order between multiple BeforeSceneLoad calls is undefined.
=> UniTask can only be used after BeforeSceneLoad

Proposed solution:
Allow unitask to initialize at AfterAssembliesLoaded, so it can be safely used during BeforeSceneLoad.
To keep compatability with older versions, the change is gated behind a unity version define.