### PR TITLE
add EditorUpdate special timing to support EditorApplication.update tick

### DIFF
--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/Internal/PlayerLoopRunner.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/Internal/PlayerLoopRunner.cs
@@ -76,6 +76,10 @@ namespace Cysharp.Threading.Tasks.Internal
 #if DEBUG
             switch (timing)
             {
+                case PlayerLoopTiming.EditorUpdate:
+                    EditorUpdate();
+                    break;
+                
                 case PlayerLoopTiming.Initialization:
                     Initialization();
                     break;
@@ -134,6 +138,7 @@ namespace Cysharp.Threading.Tasks.Internal
 #endif
         }
 
+        void EditorUpdate() => RunCore();
         void Initialization() => RunCore();
         void LastInitialization() => RunCore();
         void EarlyUpdate() => RunCore();


### PR DESCRIPTION
this addresses issue #490 I just opened. it might break logic for existing editor tasks that assume `PlayerLoopTiming.Update` or similar, but I believe it's a much cleaner solution that separates the timing of the player loop from the editor one.