### PR TITLE
Fix conditions for UniTaskCompletionSourceCore.TrySet* to be true

### DIFF
--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTaskCompletionSource.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTaskCompletionSource.cs
@@ -137,8 +137,8 @@ namespace Cysharp.Threading.Tasks
                 if (continuation != null || Interlocked.CompareExchange(ref this.continuation, UniTaskCompletionSourceCoreShared.s_sentinel, null) != null)
                 {
                     continuation(continuationState);
-                    return true;
                 }
+                return true;
             }
 
             return false;
@@ -165,8 +165,8 @@ namespace Cysharp.Threading.Tasks
                 if (continuation != null || Interlocked.CompareExchange(ref this.continuation, UniTaskCompletionSourceCoreShared.s_sentinel, null) != null)
                 {
                     continuation(continuationState);
-                    return true;
                 }
+                return true;
             }
 
             return false;
@@ -184,8 +184,8 @@ namespace Cysharp.Threading.Tasks
                 if (continuation != null || Interlocked.CompareExchange(ref this.continuation, UniTaskCompletionSourceCoreShared.s_sentinel, null) != null)
                 {
                     continuation(continuationState);
-                    return true;
                 }
+                return true;
             }
 
             return false;


### PR DESCRIPTION
About the TrySetResult family of UniTaskCompletionSourceCore,
It is expected that true will be returned if set succeeds. However, if continuation is not set, the return value seems to be false.

I would like to correct this to the expected behavior.

I visually checked :eyes: .   the return value was not actually used, so this change is probably no impact.