### PR TITLE
Use always innerException for Task.AsUniTask

### DIFF
--- a/src/UniTask.NetCoreTests/TaskExtensionsTest.cs
+++ b/src/UniTask.NetCoreTests/TaskExtensionsTest.cs
@@ -20,6 +20,15 @@ namespace NetCoreTests
                 await ThrowOrValueAsync().AsUniTask();
             });
         }
+
+        [Fact]
+        public async Task PropagateExceptionWhenAll()
+        {
+            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await Task.WhenAll(ThrowAsync(), ThrowAsync()).AsUniTask();
+            });
+        }
  
         async Task ThrowAsync()
         {

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTaskExtensions.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTaskExtensions.cs
@@ -28,7 +28,7 @@ namespace Cysharp.Threading.Tasks
                         p.TrySetCanceled();
                         break;
                     case TaskStatus.Faulted:
-                        p.TrySetException(x.Exception.InnerException);
+                        p.TrySetException(x.Exception.InnerException ?? x.Exception);
                         break;
                     case TaskStatus.RanToCompletion:
                         p.TrySetResult(x.Result);
@@ -58,7 +58,7 @@ namespace Cysharp.Threading.Tasks
                         p.TrySetCanceled();
                         break;
                     case TaskStatus.Faulted:
-                        p.TrySetException(x.Exception.InnerException);
+                        p.TrySetException(x.Exception.InnerException ?? x.Exception);
                         break;
                     case TaskStatus.RanToCompletion:
                         p.TrySetResult();

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTaskExtensions.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTaskExtensions.cs
@@ -28,7 +28,7 @@ namespace Cysharp.Threading.Tasks
                         p.TrySetCanceled();
                         break;
                     case TaskStatus.Faulted:
-                        p.TrySetException(x.Exception.InnerExceptions.Count == 1 ? x.Exception.InnerException : x.Exception);
+                        p.TrySetException(x.Exception.InnerException);
                         break;
                     case TaskStatus.RanToCompletion:
                         p.TrySetResult(x.Result);
@@ -58,7 +58,7 @@ namespace Cysharp.Threading.Tasks
                         p.TrySetCanceled();
                         break;
                     case TaskStatus.Faulted:
-                        p.TrySetException(x.Exception.InnerExceptions.Count == 1 ? x.Exception.InnerException : x.Exception);
+                        p.TrySetException(x.Exception.InnerException);
                         break;
                     case TaskStatus.RanToCompletion:
                         p.TrySetResult();


### PR DESCRIPTION
refs: #422 

After #486, There was some further discussion.

> UniTask is a world line like Task when there is only await, so it may be possible to throw away other exceptions to match the behavior of await Task...

So, if `await Task.WhenAll(...).AsUniTask()` throws an exception,  always use inner exception just like `await Task.WhenAll(...)`.