### PR TITLE
UniTask does not work in .NET Framework environment after adding UniTask.AsValueTask

### DIFF
--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/IUniTaskSource.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/IUniTaskSource.cs
@@ -19,7 +19,7 @@ namespace Cysharp.Threading.Tasks
 
     // similar as IValueTaskSource
     public interface IUniTaskSource
-#if (!UNITY_2018_3_OR_NEWER || UNITY_2021_2_OR_NEWER) && !NETSTANDARD2_0
+#if !UNITY_2018_3_OR_NEWER && UNITY_2021_2_OR_NEWER && !NETSTANDARD2_0
         : System.Threading.Tasks.Sources.IValueTaskSource
 #pragma warning disable CS0108
 #endif
@@ -30,7 +30,7 @@ namespace Cysharp.Threading.Tasks
 
         UniTaskStatus UnsafeGetStatus(); // only for debug use.
 
-#if (!UNITY_2018_3_OR_NEWER || UNITY_2021_2_OR_NEWER) && !NETSTANDARD2_0
+#if !UNITY_2018_3_OR_NEWER && UNITY_2021_2_OR_NEWER && !NETSTANDARD2_0
 #pragma warning restore CS0108
 
         System.Threading.Tasks.Sources.ValueTaskSourceStatus System.Threading.Tasks.Sources.IValueTaskSource.GetStatus(short token)
@@ -53,13 +53,13 @@ namespace Cysharp.Threading.Tasks
     }
 
     public interface IUniTaskSource<out T> : IUniTaskSource
-#if (!UNITY_2018_3_OR_NEWER || UNITY_2021_2_OR_NEWER) && !NETSTANDARD2_0
+#if !UNITY_2018_3_OR_NEWER && UNITY_2021_2_OR_NEWER && !NETSTANDARD2_0
         , System.Threading.Tasks.Sources.IValueTaskSource<T>
 #endif
     {
         new T GetResult(short token);
 
-#if (!UNITY_2018_3_OR_NEWER || UNITY_2021_2_OR_NEWER) && !NETSTANDARD2_0
+#if !UNITY_2018_3_OR_NEWER && UNITY_2021_2_OR_NEWER && !NETSTANDARD2_0
 
         new public UniTaskStatus GetStatus(short token)
         {

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/IUniTaskSource.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/IUniTaskSource.cs
@@ -19,7 +19,7 @@ namespace Cysharp.Threading.Tasks
 
     // similar as IValueTaskSource
     public interface IUniTaskSource
-#if !UNITY_2018_3_OR_NEWER && UNITY_2021_2_OR_NEWER && !NETSTANDARD2_0
+#if (!UNITY_2018_3_OR_NEWER || UNITY_2021_2_OR_NEWER) && !NETSTANDARD2_0
         : System.Threading.Tasks.Sources.IValueTaskSource
 #pragma warning disable CS0108
 #endif
@@ -30,7 +30,7 @@ namespace Cysharp.Threading.Tasks
 
         UniTaskStatus UnsafeGetStatus(); // only for debug use.
 
-#if !UNITY_2018_3_OR_NEWER && UNITY_2021_2_OR_NEWER && !NETSTANDARD2_0
+#if (!UNITY_2018_3_OR_NEWER || UNITY_2021_2_OR_NEWER) && !NETSTANDARD2_0
 #pragma warning restore CS0108
 
         System.Threading.Tasks.Sources.ValueTaskSourceStatus System.Threading.Tasks.Sources.IValueTaskSource.GetStatus(short token)
@@ -53,13 +53,13 @@ namespace Cysharp.Threading.Tasks
     }
 
     public interface IUniTaskSource<out T> : IUniTaskSource
-#if !UNITY_2018_3_OR_NEWER && UNITY_2021_2_OR_NEWER && !NETSTANDARD2_0
+#if (!UNITY_2018_3_OR_NEWER || UNITY_2021_2_OR_NEWER) && !NETSTANDARD2_0
         , System.Threading.Tasks.Sources.IValueTaskSource<T>
 #endif
     {
         new T GetResult(short token);
 
-#if !UNITY_2018_3_OR_NEWER && UNITY_2021_2_OR_NEWER && !NETSTANDARD2_0
+#if (!UNITY_2018_3_OR_NEWER || UNITY_2021_2_OR_NEWER) && !NETSTANDARD2_0
 
         new public UniTaskStatus GetStatus(short token)
         {

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/IUniTaskSource.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/IUniTaskSource.cs
@@ -19,7 +19,7 @@ namespace Cysharp.Threading.Tasks
 
     // similar as IValueTaskSource
     public interface IUniTaskSource
-#if (!UNITY_2018_3_OR_NEWER || UNITY_2021_2_OR_NEWER) && !NETSTANDARD2_0
+#if (!UNITY_2018_3_OR_NEWER || UNITY_2022_3_OR_NEWER) && !NETSTANDARD2_0
         : System.Threading.Tasks.Sources.IValueTaskSource
 #pragma warning disable CS0108
 #endif
@@ -30,7 +30,7 @@ namespace Cysharp.Threading.Tasks
 
         UniTaskStatus UnsafeGetStatus(); // only for debug use.
 
-#if (!UNITY_2018_3_OR_NEWER || UNITY_2021_2_OR_NEWER) && !NETSTANDARD2_0
+#if (!UNITY_2018_3_OR_NEWER || UNITY_2022_3_OR_NEWER) && !NETSTANDARD2_0
 #pragma warning restore CS0108
 
         System.Threading.Tasks.Sources.ValueTaskSourceStatus System.Threading.Tasks.Sources.IValueTaskSource.GetStatus(short token)
@@ -53,13 +53,13 @@ namespace Cysharp.Threading.Tasks
     }
 
     public interface IUniTaskSource<out T> : IUniTaskSource
-#if (!UNITY_2018_3_OR_NEWER || UNITY_2021_2_OR_NEWER) && !NETSTANDARD2_0
+#if (!UNITY_2018_3_OR_NEWER || UNITY_2022_3_OR_NEWER) && !NETSTANDARD2_0
         , System.Threading.Tasks.Sources.IValueTaskSource<T>
 #endif
     {
         new T GetResult(short token);
 
-#if (!UNITY_2018_3_OR_NEWER || UNITY_2021_2_OR_NEWER) && !NETSTANDARD2_0
+#if (!UNITY_2018_3_OR_NEWER || UNITY_2022_3_OR_NEWER) && !NETSTANDARD2_0
 
         new public UniTaskStatus GetStatus(short token)
         {

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTask.AsValueTask.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTask.AsValueTask.cs
@@ -1,4 +1,4 @@
-﻿#if !UNITY_2018_3_OR_NEWER && UNITY_2021_2_OR_NEWER
+﻿#if !UNITY_2018_3_OR_NEWER || UNITY_2021_2_OR_NEWER
 #pragma warning disable 0649
 
 using System;

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTask.AsValueTask.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTask.AsValueTask.cs
@@ -1,4 +1,4 @@
-﻿#if !UNITY_2018_3_OR_NEWER || UNITY_2021_2_OR_NEWER
+﻿#if !UNITY_2018_3_OR_NEWER && UNITY_2021_2_OR_NEWER
 #pragma warning disable 0649
 
 using System;

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTask.AsValueTask.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTask.AsValueTask.cs
@@ -1,4 +1,4 @@
-﻿#if !UNITY_2018_3_OR_NEWER || UNITY_2021_2_OR_NEWER
+﻿#if !UNITY_2018_3_OR_NEWER || UNITY_2022_3_OR_NEWER
 #pragma warning disable 0649
 
 using System;

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTask.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTask.cs
@@ -69,7 +69,7 @@ namespace Cysharp.Threading.Tasks
             return new UniTask<bool>(new IsCanceledSource(source), token);
         }
 
-#if !UNITY_2018_3_OR_NEWER && UNITY_2021_2_OR_NEWER
+#if !UNITY_2018_3_OR_NEWER || UNITY_2021_2_OR_NEWER
 
         public static implicit operator System.Threading.Tasks.ValueTask(in UniTask self)
         {
@@ -440,7 +440,7 @@ namespace Cysharp.Threading.Tasks
             return self.AsUniTask();
         }
 
-#if !UNITY_2018_3_OR_NEWER && UNITY_2021_2_OR_NEWER
+#if !UNITY_2018_3_OR_NEWER || UNITY_2021_2_OR_NEWER
 
         public static implicit operator System.Threading.Tasks.ValueTask<T>(in UniTask<T> self)
         {

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTask.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTask.cs
@@ -69,7 +69,7 @@ namespace Cysharp.Threading.Tasks
             return new UniTask<bool>(new IsCanceledSource(source), token);
         }
 
-#if !UNITY_2018_3_OR_NEWER || UNITY_2021_2_OR_NEWER
+#if !UNITY_2018_3_OR_NEWER && UNITY_2021_2_OR_NEWER
 
         public static implicit operator System.Threading.Tasks.ValueTask(in UniTask self)
         {
@@ -440,7 +440,7 @@ namespace Cysharp.Threading.Tasks
             return self.AsUniTask();
         }
 
-#if !UNITY_2018_3_OR_NEWER || UNITY_2021_2_OR_NEWER
+#if !UNITY_2018_3_OR_NEWER && UNITY_2021_2_OR_NEWER
 
         public static implicit operator System.Threading.Tasks.ValueTask<T>(in UniTask<T> self)
         {

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTask.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTask.cs
@@ -69,7 +69,7 @@ namespace Cysharp.Threading.Tasks
             return new UniTask<bool>(new IsCanceledSource(source), token);
         }
 
-#if !UNITY_2018_3_OR_NEWER || UNITY_2021_2_OR_NEWER
+#if !UNITY_2018_3_OR_NEWER || UNITY_2022_3_OR_NEWER
 
         public static implicit operator System.Threading.Tasks.ValueTask(in UniTask self)
         {
@@ -440,7 +440,7 @@ namespace Cysharp.Threading.Tasks
             return self.AsUniTask();
         }
 
-#if !UNITY_2018_3_OR_NEWER || UNITY_2021_2_OR_NEWER
+#if !UNITY_2018_3_OR_NEWER || UNITY_2022_3_OR_NEWER
 
         public static implicit operator System.Threading.Tasks.ValueTask<T>(in UniTask<T> self)
         {


### PR DESCRIPTION
Probably after #533 was implemented, I started getting the following error in the .NET Framework environment of Unity2021.

> Library\PackageCache\com.cysharp.unitask.........\Runtime\IUniTaskSource.cs(55,41): error CS1961: Invalid variance: The type parameter 'T' must be invariantly valid on 'IValueTaskSource<T>'. 'T' is covariant.

This is a modification of that, revising the conditional compilation section.

However, the error itself does not seem to be a case of missing definitions, so there may be an answer that takes into account the .NET Framework environment.

Either way, the fix for this problem seems urgent.