### PR TITLE
Fix "Release handle when cancellation is requested"

### DIFF
--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/External/Addressables/AddressablesAsyncExtensions.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/External/Addressables/AddressablesAsyncExtensions.cs
@@ -7,6 +7,7 @@ using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Threading;
+using UnityEngine.AddressableAssets;
 using UnityEngine.ResourceManagement.AsyncOperations;
 
 namespace Cysharp.Threading.Tasks
@@ -171,6 +172,10 @@ namespace Cysharp.Threading.Tasks
                     completed = true;
                     if (cancellationToken.IsCancellationRequested)
                     {
+                        If (handle.IsValid())
+                        {
+                            Addressables.Release(handle);
+                        }
                         core.TrySetCanceled(cancellationToken);
                     }
                     else if (handle.Status == AsyncOperationStatus.Failed)
@@ -215,6 +220,10 @@ namespace Cysharp.Threading.Tasks
                 if (cancellationToken.IsCancellationRequested)
                 {
                     completed = true;
+                    if (handle.IsValid())
+                    {
+                        Addressables.Release(handle);
+                    }
                     core.TrySetCanceled(cancellationToken);
                     return false;
                 }
@@ -353,6 +362,10 @@ namespace Cysharp.Threading.Tasks
                     completed = true;
                     if (cancellationToken.IsCancellationRequested)
                     {
+                        if (handle.IsValid())
+                        {
+                            Addressables.Release(handle);
+                        }
                         core.TrySetCanceled(cancellationToken);
                     }
                     else if (argHandle.Status == AsyncOperationStatus.Failed)
@@ -402,6 +415,10 @@ namespace Cysharp.Threading.Tasks
                 if (cancellationToken.IsCancellationRequested)
                 {
                     completed = true;
+                    if (handle.IsValid())
+                    {
+                        Addressables.Release(handle);
+                    }
                     core.TrySetCanceled(cancellationToken);
                     return false;
                 }

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/External/Addressables/UniTask.Addressables.asmdef
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/External/Addressables/UniTask.Addressables.asmdef
@@ -2,7 +2,8 @@
     "name": "UniTask.Addressables",
     "references": [
         "UniTask",
-        "Unity.ResourceManager"
+        "Unity.ResourceManager",
+        "Unity.Addressables"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
refs: https://github.com/Cysharp/UniTask/pull/521#issuecomment-1909695098

This is a modified version of the PR #521  as commented.

EDIT:
- Add a new `autoReleaseWhenCancelled` flag because `Addressable.Release` would be a breaking change.