### PR TITLE
Optimization of ToArray in Merge method

### DIFF
--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/Linq/Merge.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/Linq/Merge.cs
@@ -27,7 +27,9 @@ namespace Cysharp.Threading.Tasks.Linq
 
         public static IUniTaskAsyncEnumerable<T> Merge<T>(this IEnumerable<IUniTaskAsyncEnumerable<T>> sources)
         {
-            return new Merge<T>(sources.ToArray());
+            return sources is IUniTaskAsyncEnumerable<T>[] array
+                ? new Merge<T>(array)
+                : new Merge<T>(sources.ToArray());
         }
 
         public static IUniTaskAsyncEnumerable<T> Merge<T>(params IUniTaskAsyncEnumerable<T>[] sources)


### PR DESCRIPTION
If IEnumerable<T> is an array, unnecessary ToArray calls are no longer made.