### PR TITLE
Support awaiting additional engine callbacks

### DIFF
--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/Internal/ContinuationRunner.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/Internal/ContinuationRunner.cs
@@ -1,0 +1,172 @@
+
+using System;
+using UnityEngine;
+
+namespace Cysharp.Threading.Tasks.Internal
+{
+    internal abstract class ContinuationRunner
+    {
+        const int InitialSize = 16;
+
+        readonly object runningAndQueueLock = new object();
+        readonly object arrayLock = new object();
+        readonly Action<Exception> unhandledExceptionCallback;
+
+        int tail = 0;
+        bool running = false;
+        IPlayerLoopItem[] loopItems = new IPlayerLoopItem[InitialSize];
+        MinimumQueue<IPlayerLoopItem> waitQueue = new MinimumQueue<IPlayerLoopItem>(InitialSize);
+
+
+        public ContinuationRunner()
+        {
+            this.unhandledExceptionCallback = ex => Debug.LogException(ex);
+        }
+
+        public void AddAction(IPlayerLoopItem item)
+        {
+            lock (runningAndQueueLock)
+            {
+                if (running)
+                {
+                    waitQueue.Enqueue(item);
+                    return;
+                }
+            }
+
+            lock (arrayLock)
+            {
+                // Ensure Capacity
+                if (loopItems.Length == tail)
+                {
+                    Array.Resize(ref loopItems, checked(tail * 2));
+                }
+                loopItems[tail++] = item;
+            }
+        }
+
+        public int Clear()
+        {
+            lock (arrayLock)
+            {
+                var rest = 0;
+
+                for (var index = 0; index < loopItems.Length; index++)
+                {
+                    if (loopItems[index] != null)
+                    {
+                        rest++;
+                    }
+
+                    loopItems[index] = null;
+                }
+
+                tail = 0;
+                return rest;
+            }
+        }
+
+        [System.Diagnostics.DebuggerHidden]
+        protected void RunCore()
+        {
+            lock (runningAndQueueLock)
+            {
+                running = true;
+            }
+
+            lock (arrayLock)
+            {
+                var j = tail - 1;
+
+                for (int i = 0; i < loopItems.Length; i++)
+                {
+                    var action = loopItems[i];
+                    if (action != null)
+                    {
+                        try
+                        {
+                            if (!action.MoveNext())
+                            {
+                                loopItems[i] = null;
+                            }
+                            else
+                            {
+                                continue; // next i 
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            loopItems[i] = null;
+                            try
+                            {
+                                unhandledExceptionCallback(ex);
+                            }
+                            catch { }
+                        }
+                    }
+
+                    // find null, loop from tail
+                    while (i < j)
+                    {
+                        var fromTail = loopItems[j];
+                        if (fromTail != null)
+                        {
+                            try
+                            {
+                                if (!fromTail.MoveNext())
+                                {
+                                    loopItems[j] = null;
+                                    j--;
+                                    continue; // next j
+                                }
+                                else
+                                {
+                                    // swap
+                                    loopItems[i] = fromTail;
+                                    loopItems[j] = null;
+                                    j--;
+                                    goto NEXT_LOOP; // next i
+                                }
+                            }
+                            catch (Exception ex)
+                            {
+                                loopItems[j] = null;
+                                j--;
+                                try
+                                {
+                                    unhandledExceptionCallback(ex);
+                                }
+                                catch { }
+                                continue; // next j
+                            }
+                        }
+                        else
+                        {
+                            j--;
+                        }
+                    }
+
+                    tail = i; // loop end
+                    break; // LOOP END
+
+                NEXT_LOOP:
+                    continue;
+                }
+
+
+                lock (runningAndQueueLock)
+                {
+                    running = false;
+                    while (waitQueue.Count != 0)
+                    {
+                        if (loopItems.Length == tail)
+                        {
+                            Array.Resize(ref loopItems, checked(tail * 2));
+                        }
+                        loopItems[tail++] = waitQueue.Dequeue();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/Internal/ContinuationRunner.cs.meta
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/Internal/ContinuationRunner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4f21ae8b72659b348af5ebb66b84b07b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/Internal/EngineCallbackRunner.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/Internal/EngineCallbackRunner.cs
@@ -24,7 +24,7 @@ namespace Cysharp.Threading.Tasks.Internal
                 case EngineCallbackTiming.WillRenderCanvases:
                     WillRenderCanvases();
                     break;
-#if UNITY_2021_3_OR_NEWER
+#if UNITY_2020_3_OR_NEWER
                 case EngineCallbackTiming.PreWillRenderCanvases:
                     PreWillRenderCanvases();
                     break;
@@ -40,7 +40,7 @@ namespace Cysharp.Threading.Tasks.Internal
 
         void OnBeforeRender() => RunCore();
         void WillRenderCanvases() => RunCore();
-#if UNITY_2021_3_OR_NEWER
+#if UNITY_2020_3_OR_NEWER
         void PreWillRenderCanvases() => RunCore();
 #endif
     }

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/Internal/EngineCallbackRunner.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/Internal/EngineCallbackRunner.cs
@@ -1,0 +1,47 @@
+
+namespace Cysharp.Threading.Tasks.Internal
+{
+    internal sealed class EngineCallbackRunner : ContinuationRunner
+    {
+        readonly EngineCallbackTiming timing;
+
+
+        public EngineCallbackRunner(EngineCallbackTiming timing) : base()
+        {
+            this.timing = timing;
+        }
+
+        // delegate entrypoint.
+        public void Run()
+        {
+            // for debugging, create named stacktrace.
+#if DEBUG
+            switch (timing)
+            {
+                case EngineCallbackTiming.OnBeforeRender:
+                    OnBeforeRender();
+                    break;
+                case EngineCallbackTiming.WillRenderCanvases:
+                    WillRenderCanvases();
+                    break;
+#if UNITY_2021_3_OR_NEWER
+                case EngineCallbackTiming.PreWillRenderCanvases:
+                    PreWillRenderCanvases();
+                    break;
+#endif
+
+                default:
+                    break;
+            }
+#else
+            RunCore();
+#endif
+        }
+
+        void OnBeforeRender() => RunCore();
+        void WillRenderCanvases() => RunCore();
+#if UNITY_2021_3_OR_NEWER
+        void PreWillRenderCanvases() => RunCore();
+#endif
+    }
+}

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/Internal/EngineCallbackRunner.cs.meta
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/Internal/EngineCallbackRunner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 10e6588bde350b3418e72c3cd963f5f3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/Internal/PlayerLoopRunner.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/Internal/PlayerLoopRunner.cs
@@ -1,72 +1,14 @@
 ﻿
-using System;
-using UnityEngine;
-
 namespace Cysharp.Threading.Tasks.Internal
 {
-    internal sealed class PlayerLoopRunner
+    internal sealed class PlayerLoopRunner : ContinuationRunner
     {
-        const int InitialSize = 16;
-
         readonly PlayerLoopTiming timing;
-        readonly object runningAndQueueLock = new object();
-        readonly object arrayLock = new object();
-        readonly Action<Exception> unhandledExceptionCallback;
-
-        int tail = 0;
-        bool running = false;
-        IPlayerLoopItem[] loopItems = new IPlayerLoopItem[InitialSize];
-        MinimumQueue<IPlayerLoopItem> waitQueue = new MinimumQueue<IPlayerLoopItem>(InitialSize);
 
 
-
-        public PlayerLoopRunner(PlayerLoopTiming timing)
+        public PlayerLoopRunner(PlayerLoopTiming timing) : base()
         {
-            this.unhandledExceptionCallback = ex => Debug.LogException(ex);
             this.timing = timing;
-        }
-
-        public void AddAction(IPlayerLoopItem item)
-        {
-            lock (runningAndQueueLock)
-            {
-                if (running)
-                {
-                    waitQueue.Enqueue(item);
-                    return;
-                }
-            }
-
-            lock (arrayLock)
-            {
-                // Ensure Capacity
-                if (loopItems.Length == tail)
-                {
-                    Array.Resize(ref loopItems, checked(tail * 2));
-                }
-                loopItems[tail++] = item;
-            }
-        }
-
-        public int Clear()
-        {
-            lock (arrayLock)
-            {
-                var rest = 0;
-
-                for (var index = 0; index < loopItems.Length; index++)
-                {
-                    if (loopItems[index] != null)
-                    {
-                        rest++;
-                    }
-
-                    loopItems[index] = null;
-                }
-
-                tail = 0;
-                return rest;
-            }
         }
 
         // delegate entrypoint.
@@ -152,109 +94,6 @@ namespace Cysharp.Threading.Tasks.Internal
         void TimeUpdate() => RunCore();
         void LastTimeUpdate() => RunCore();
 #endif
-
-        [System.Diagnostics.DebuggerHidden]
-        void RunCore()
-        {
-            lock (runningAndQueueLock)
-            {
-                running = true;
-            }
-
-            lock (arrayLock)
-            {
-                var j = tail - 1;
-
-                for (int i = 0; i < loopItems.Length; i++)
-                {
-                    var action = loopItems[i];
-                    if (action != null)
-                    {
-                        try
-                        {
-                            if (!action.MoveNext())
-                            {
-                                loopItems[i] = null;
-                            }
-                            else
-                            {
-                                continue; // next i 
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            loopItems[i] = null;
-                            try
-                            {
-                                unhandledExceptionCallback(ex);
-                            }
-                            catch { }
-                        }
-                    }
-
-                    // find null, loop from tail
-                    while (i < j)
-                    {
-                        var fromTail = loopItems[j];
-                        if (fromTail != null)
-                        {
-                            try
-                            {
-                                if (!fromTail.MoveNext())
-                                {
-                                    loopItems[j] = null;
-                                    j--;
-                                    continue; // next j
-                                }
-                                else
-                                {
-                                    // swap
-                                    loopItems[i] = fromTail;
-                                    loopItems[j] = null;
-                                    j--;
-                                    goto NEXT_LOOP; // next i
-                                }
-                            }
-                            catch (Exception ex)
-                            {
-                                loopItems[j] = null;
-                                j--;
-                                try
-                                {
-                                    unhandledExceptionCallback(ex);
-                                }
-                                catch { }
-                                continue; // next j
-                            }
-                        }
-                        else
-                        {
-                            j--;
-                        }
-                    }
-
-                    tail = i; // loop end
-                    break; // LOOP END
-
-                    NEXT_LOOP:
-                    continue;
-                }
-
-
-                lock (runningAndQueueLock)
-                {
-                    running = false;
-                    while (waitQueue.Count != 0)
-                    {
-                        if (loopItems.Length == tail)
-                        {
-                            Array.Resize(ref loopItems, checked(tail * 2));
-                        }
-                        loopItems[tail++] = waitQueue.Dequeue();
-                    }
-                }
-            }
-        }
     }
 }
 

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/PlayerLoopHelper.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/PlayerLoopHelper.cs
@@ -103,7 +103,7 @@ namespace Cysharp.Threading.Tasks
         OnBeforeRender = 0,
 
         WillRenderCanvases = 1,
-#if UNITY_2021_3_OR_NEWER
+#if UNITY_2020_3_OR_NEWER
         PreWillRenderCanvases = 2,
 #endif
     }
@@ -187,7 +187,7 @@ namespace Cysharp.Threading.Tasks
         All =
             OnBeforeRender |
             WillRenderCanvases
-#if UNITY_2021_3_OR_NEWER
+#if UNITY_2020_3_OR_NEWER
             | PreWillRenderCanvases
 #endif
         ,
@@ -195,7 +195,7 @@ namespace Cysharp.Threading.Tasks
         OnBeforeRender = 1,
 
         WillRenderCanvases = 2,
-#if UNITY_2021_3_OR_NEWER
+#if UNITY_2020_3_OR_NEWER
         PreWillRenderCanvases = 4,
 #endif
     }
@@ -448,7 +448,7 @@ namespace Cysharp.Threading.Tasks
             runners = new PlayerLoopRunner[14];
 #endif
 
-#if UNITY_2021_3_OR_NEWER
+#if UNITY_2020_3_OR_NEWER
             callbackRunners = new EngineCallbackRunner[3];
 #else
             callbackRunners = new EngineCallbackRunner[2];
@@ -549,7 +549,7 @@ namespace Cysharp.Threading.Tasks
                 Canvas.willRenderCanvases += willRenderCanvasesRunner.Run;
             }
 
-#if UNITY_2021_3_OR_NEWER
+#if UNITY_2020_3_OR_NEWER
             if (GetInjectCallback(injectCallbackTimings, InjectEngineCallbackTimings.PreWillRenderCanvases,
                 2, EngineCallbackTiming.PreWillRenderCanvases, out var preWillRenderCanvasesRunner))
             {

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTask.Delay.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTask.Delay.cs
@@ -205,7 +205,7 @@ namespace Cysharp.Threading.Tasks
             return new UniTask(YieldPromise.Create(EngineCallbackTiming.WillRenderCanvases, cancellationToken, cancelImmediately, out var token), token);
         }
 
-#if UNITY_2021_3_OR_NEWER
+#if UNITY_2020_3_OR_NEWER
         public static UniTask WaitForPreWillRenderCanvases(CancellationToken cancellationToken = default(CancellationToken), bool cancelImmediately = false)
         {
             return new UniTask(YieldPromise.Create(EngineCallbackTiming.PreWillRenderCanvases, cancellationToken, cancelImmediately, out var token), token);

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTask.Threading.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTask.Threading.cs
@@ -52,6 +52,14 @@ namespace Cysharp.Threading.Tasks
             PlayerLoopHelper.AddContinuation(timing, action);
         }
 
+        /// <summary>
+        /// Queue the action to an Engine Callback.
+        /// </summary>
+        public static void Post(Action action, EngineCallbackTiming timing)
+        {
+            PlayerLoopHelper.AddContinuation(timing, action);
+        }
+
 #endif
 
         public static SwitchToThreadPoolAwaitable SwitchToThreadPool()


### PR DESCRIPTION
Pull request adds the ability for a task to `await` the invocation of some additional Unity callbacks:

- `Application.onBeforeRender` via method `UniTask.WaitForOnBeforeRender`
- `Canvas.willRenderCanvases` via method `UniTask.WaitForWillRenderCanvases`
- `Canvas.preWillRenderCanvases` via method `UniTask.WaitForPreWillRenderCanvases`

Implementation notes:

- Additional enum `EngineCallbackTiming` defines these callbacks (similar to `PlayerLoopTiming`) with the `InjectEngineCallbackTimings` counterpart. - I figured it was best to keep these separated since they do not use the PlayerLoop.
- Core continuation-running logic was split out of `PlayerLoopRunner` into new base class `ContinuationRunner` so it could be shared with new class `EngineCallbackRunner` for these callbacks.
- The callback `WaitFor` methods utilize `YieldPromise` which was changed to accommodate the new enum with minimal changes.