### PR TITLE
Exception not prompted when using UniTask

### DIFF
--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTaskCompletionSource.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTaskCompletionSource.cs
@@ -166,6 +166,10 @@ namespace Cysharp.Threading.Tasks
                 {
                     continuation(continuationState);
                 }
+                else 
+                {
+                    UniTaskScheduler.PublishUnobservedTaskException(error);
+                }
                 return true;
             }
 

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTaskCompletionSource.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTaskCompletionSource.cs
@@ -59,13 +59,13 @@ namespace Cysharp.Threading.Tasks
             return exception;
         }
 
-        ~ExceptionHolder()
-        {
-            if (!calledGet)
-            {
-                UniTaskScheduler.PublishUnobservedTaskException(exception.SourceException);
-            }
-        }
+        //~ExceptionHolder()
+        //{
+        //    if (!calledGet)
+        //    {
+        //        UniTaskScheduler.PublishUnobservedTaskException(exception.SourceException);
+        //    }
+        //}
     }
 
     [StructLayout(LayoutKind.Auto)]


### PR DESCRIPTION
```
using Cysharp.Threading.Tasks;

namespace ConsoleApp2
{
    internal class Program
    {
        static void Main(string[] args)
        {
              Test();
              Console.ReadLine();
        }
    
        static async UniTask Test()
        {
            await UniTask.Yield();
            throw new Exception();
        }
    }
}
```