### PR TITLE
TextMeshPro Unity6 adoptions

### DIFF
--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/External/TextMeshPro/UniTask.TextMeshPro.asmdef
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/External/TextMeshPro/UniTask.TextMeshPro.asmdef
@@ -19,7 +19,7 @@
         },
         {
             "name": "com.unity.ugui",
-            "expression": "",
+            "expression": "2.0.0",
             "define": "UNITASK_TEXTMESHPRO_SUPPORT"
         }
     ],

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/External/TextMeshPro/UniTask.TextMeshPro.asmdef
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/External/TextMeshPro/UniTask.TextMeshPro.asmdef
@@ -16,6 +16,11 @@
             "name": "com.unity.textmeshpro",
             "expression": "",
             "define": "UNITASK_TEXTMESHPRO_SUPPORT"
+        },
+        {
+            "name": "com.unity.ugui",
+            "expression": "",
+            "define": "UNITASK_TEXTMESHPRO_SUPPORT"
         }
     ],
     "noEngineReferences": false


### PR DESCRIPTION
Since Unity 6 / com.unity.ugui 2.0, TextMeshPro was merged into the ugui package. 
This PR extends the UniTask.TextMeshPro.asmdef to still activate 'UNITASK_TEXTMESHPRO_SUPPORT' 