### PR TITLE
Forget ignored task

### DIFF
--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTaskExtensions.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTaskExtensions.cs
@@ -201,6 +201,7 @@ namespace Cysharp.Threading.Tasks
 
             if (cancellationToken.IsCancellationRequested)
             {
+                task.Forget();
                 return UniTask.FromCanceled(cancellationToken);
             }
 
@@ -224,6 +225,7 @@ namespace Cysharp.Threading.Tasks
 
             if (cancellationToken.IsCancellationRequested)
             {
+                task.Forget();
                 return UniTask.FromCanceled<T>(cancellationToken);
             }
 


### PR DESCRIPTION
I believe that the UniTask extension method AttachExternalCancellation should call task forget method when the cancellation token has already requested.