### PR TITLE
ci: remove Unity 2021 LTS from Build matrix

### DIFF
--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       max-parallel: 2
       matrix:
-        unity: ["2021.3.41f1", "2022.3.39f1", "6000.0.12f1"] # Test with LTS
+        unity: ["2022.3.39f1", "6000.0.12f1"] # Test with LTS
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -44,7 +44,7 @@ jobs:
       # Execute scripts: Export Package
       #  /opt/Unity/Editor/Unity -quit -batchmode -nographics -silent-crashes -logFile -projectPath . -executeMethod PackageExporter.Export
       - name: Build Unity (.unitypacakge)
-        if: ${{ startsWith(matrix.unity, '2021') }} # only execute once
+        if: ${{ startsWith(matrix.unity, '2022') }} # only execute once
         uses: Cysharp/Actions/.github/actions/unity-builder@main
         env:
           UNITY_EMAIL: ${{ steps.op-load-secret.outputs.UNITY_EMAIL }}


### PR DESCRIPTION
## tl;dr;

To speed up CI, and 2021 LTS will end support when Unity 6 released, later 2024. (Officially already end but currently [extending](https://unity.com/blog/unity-2021-long-term-support-extended?ref=dailydev))