### PR TITLE
Add TMP_Dropdown extension

### DIFF
--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/External/TextMeshPro/TextMeshProAsyncExtensions.Dropdown.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/External/TextMeshPro/TextMeshProAsyncExtensions.Dropdown.cs
@@ -1,0 +1,43 @@
+﻿#if UNITASK_TEXTMESHPRO_SUPPORT
+
+using System;
+using System.Threading;
+using TMPro;
+
+namespace Cysharp.Threading.Tasks
+{
+    public static partial class TextMeshProAsyncExtensions
+    {
+        public static IAsyncValueChangedEventHandler<int> GetAsyncValueChangedEventHandler(this TMP_Dropdown dropdown)
+        {
+            return new AsyncUnityEventHandler<int>(dropdown.onValueChanged, dropdown.GetCancellationTokenOnDestroy(), false);
+        }
+
+        public static IAsyncValueChangedEventHandler<int> GetAsyncValueChangedEventHandler(this TMP_Dropdown dropdown, CancellationToken cancellationToken)
+        {
+            return new AsyncUnityEventHandler<int>(dropdown.onValueChanged, cancellationToken, false);
+        }
+
+        public static UniTask<int> OnValueChangedAsync(this TMP_Dropdown dropdown)
+        {
+            return new AsyncUnityEventHandler<int>(dropdown.onValueChanged, dropdown.GetCancellationTokenOnDestroy(), true).OnInvokeAsync();
+        }
+
+        public static UniTask<int> OnValueChangedAsync(this TMP_Dropdown dropdown, CancellationToken cancellationToken)
+        {
+            return new AsyncUnityEventHandler<int>(dropdown.onValueChanged, cancellationToken, true).OnInvokeAsync();
+        }
+
+        public static IUniTaskAsyncEnumerable<int> OnValueChangedAsAsyncEnumerable(this TMP_Dropdown dropdown)
+        {
+            return new UnityEventHandlerAsyncEnumerable<int>(dropdown.onValueChanged, dropdown.GetCancellationTokenOnDestroy());
+        }
+
+        public static IUniTaskAsyncEnumerable<int> OnValueChangedAsAsyncEnumerable(this TMP_Dropdown dropdown, CancellationToken cancellationToken)
+        {
+            return new UnityEventHandlerAsyncEnumerable<int>(dropdown.onValueChanged, cancellationToken);
+        }
+    }
+}
+
+#endif

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/External/TextMeshPro/TextMeshProAsyncExtensions.Dropdown.cs.meta
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/External/TextMeshPro/TextMeshProAsyncExtensions.Dropdown.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: b858132b120c42b99cac55fd06dd32d3
+timeCreated: 1736165018


### PR DESCRIPTION
Added an extension to the Dropdown component of TextMeshPro.

```cs
using Cysharp.Threading.Tasks;
using Cysharp.Threading.Tasks.Linq;
using TMPro;
using UnityEngine;

namespace Sandboxes
{
    public class Sandbox: MonoBehaviour
    {
        [SerializeField] private TMP_Dropdown _dropdown;

        async UniTaskVoid Start()
        {
            // IAsyncValueChangedEventHandler
            var changed = await _dropdown
                .GetAsyncValueChangedEventHandler(destroyCancellationToken)
                .OnValueChangedAsync();

            Debug.Log($"Selected index: {changed}");

            // IUniTaskAsyncEnumerable
            _dropdown
                .OnValueChangedAsAsyncEnumerable(destroyCancellationToken)
                .Subscribe(x => { Debug.Log($"Selected index: {x}"); });
        }
    }
}
```