### PR TITLE
Update ToCoroutineEnumerator<T> to return a T? from Current instead of object

### DIFF
--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTaskExtensions.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTaskExtensions.cs
@@ -854,7 +854,7 @@ namespace Cysharp.Threading.Tasks
             Action<Exception> exceptionHandler = null;
             bool isStarted = false;
             UniTask<T> task;
-            T current = null;
+            T? current = null;
             ExceptionDispatchInfo exception;
 
             public ToCoroutineEnumerator(UniTask<T> task, Action<T> resultHandler, Action<Exception> exceptionHandler)
@@ -893,7 +893,7 @@ namespace Cysharp.Threading.Tasks
                 }
             }
 
-            public T Current => current;
+            public T? Current => current;
 
             public bool MoveNext()
             {

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTaskExtensions.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTaskExtensions.cs
@@ -854,7 +854,7 @@ namespace Cysharp.Threading.Tasks
             Action<Exception> exceptionHandler = null;
             bool isStarted = false;
             UniTask<T> task;
-            object current = null;
+            T current = null;
             ExceptionDispatchInfo exception;
 
             public ToCoroutineEnumerator(UniTask<T> task, Action<T> resultHandler, Action<Exception> exceptionHandler)
@@ -893,7 +893,7 @@ namespace Cysharp.Threading.Tasks
                 }
             }
 
-            public object Current => current;
+            public T Current => current;
 
             public bool MoveNext()
             {


### PR DESCRIPTION
`ToCoroutine<T>()` provides an excellent way to port existing synchronous calls to asynchronous without needing to fully rewrite everything - when inside a coroutine, it can be yielded instead.

To get the value that the previously-synchronous function would have returned, you use `.Current`. Right now, `Current` is an `object`, when it should be a `T`. I think this might have been to avoid problems with non-nullable / reference types, so I wrapped it in `Nullable` (with `T?`).

Eliminates extra unnecessary typecasting with this.