### PR TITLE
fix: EnumeratorPromise.MoveNext() gets stuck in Edit Mode

### DIFF
--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/EnumeratorAsyncExtensions.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/EnumeratorAsyncExtensions.cs
@@ -160,6 +160,7 @@ namespace Cysharp.Threading.Tasks
                 }
                 else if (initialFrame == Time.frameCount)
                 {
+                    initialFrame = -2; // mark as skipped for Edit Mode, where Time.frameCount does not advance regularly.
                     return true; // already executed in first frame, skip.
                 }
 


### PR DESCRIPTION
In Edit Mode Time.frameCount does not advance regularly and the condition for skipping at the first frame will be continuously met so that EnumeratorPromise.MoveNext() gets stuck. This prevents the use of ToUniTask in Unity's Edit Tests.